### PR TITLE
Fix companion object name being doubled in search results

### DIFF
--- a/lib/src/cellar/TypePrinter.scala
+++ b/lib/src/cellar/TypePrinter.scala
@@ -93,8 +93,10 @@ object TypePrinter:
 
       case term: TermSymbol =>
         val keyword = termKeyword(term)
-        val sig     = printMethodic(term.declaredType)
-        s"$keyword ${term.name}$sig"
+        if term.isModuleVal then s"$keyword ${term.name}"
+        else
+          val sig = printMethodic(term.declaredType)
+          s"$keyword ${term.name}$sig"
 
       case other => other.toString
 

--- a/lib/test/src/cellar/TypePrinterTest.scala
+++ b/lib/test/src/cellar/TypePrinterTest.scala
@@ -69,6 +69,26 @@ class TypePrinterTest extends CatsEffectSuite:
                 }
     yield result
 
+  test("printSymbolSignature for companion object term does not double the name"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        val term = ctx.findStaticTerm("cellar.fixture.scala3.CellarTC")
+        val sig  = TypePrinter.printSymbolSignature(term)
+        assertEquals(sig, "object CellarTC")
+      }
+    }
+
+  test("printSymbolSignature for companion object class prints module class name"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        val cls = ctx.findStaticModuleClass("cellar.fixture.scala3.CellarTC")
+        val sig = TypePrinter.printSymbolSignature(cls)
+        assert(sig.startsWith("object"), s"Expected 'object' keyword in: $sig")
+      }
+    }
+
   test("printSymbolSignatureSafe does not throw for Java symbol"):
     withCtx { ctx =>
       IO.blocking {


### PR DESCRIPTION
  Module val symbols (companion objects) were printing both the term name
  and their declared type (a TypeRef to the module class), producing
  output like "object LoggerSupportLoggerSupport$". Skip the type
  signature for module vals since "object Name" is sufficient.

  Fixes #11

  Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>