### PR TITLE
Fix CPU starvation warning in MillBuildTool classpath extraction

### DIFF
--- a/lib/src/cellar/AllSymbolsStream.scala
+++ b/lib/src/cellar/AllSymbolsStream.scala
@@ -21,4 +21,4 @@ object AllSymbolsStream:
           })
           .flatMap(syms => Stream.emits(syms))
       }
-      .filter(PublicApiFilter.isPublic)
+      .evalFilter(sym => IO.blocking(PublicApiFilter.isPublic(sym)))

--- a/lib/src/cellar/SymbolLister.scala
+++ b/lib/src/cellar/SymbolLister.scala
@@ -36,10 +36,10 @@ object SymbolLister:
         Stream
           .eval(IO.blocking(pkg.declarations))
           .flatMap(decls => Stream.emits(decls))
-          .filter(PublicApiFilter.isPublic)
+          .evalFilter(sym => IO.blocking(PublicApiFilter.isPublic(sym)))
 
       case ListTarget.Cls(cls) =>
         Stream
           .eval(IO.blocking(SymbolResolver.collectClassMembers(cls)))
           .flatMap(syms => Stream.emits(syms))
-          .filter(PublicApiFilter.isPublic)
+          .evalFilter(sym => IO.blocking(PublicApiFilter.isPublic(sym)))

--- a/lib/src/cellar/build/MillBuildTool.scala
+++ b/lib/src/cellar/build/MillBuildTool.scala
@@ -21,7 +21,7 @@ class MillBuildTool(cwd: Path, binary: String = "./mill") extends BuildTool:
       for
         compileResult <- ProcessRunner.run(List(binary, "show", s"$mod.compile"), Some(cwd))
         _ <- checkCompileResult(compileResult, mod)
-        classesDir = parseClassesDir(compileResult.stdout)
+        classesDir <- IO.blocking(parseClassesDir(compileResult.stdout))
         cpResult <- ProcessRunner.run(List(binary, "show", s"$mod.compileClasspath"), Some(cwd))
         paths <- parseClasspathResult(cpResult, classesDir)
       yield paths
@@ -38,9 +38,10 @@ class MillBuildTool(cwd: Path, binary: String = "./mill") extends BuildTool:
     if result.exitCode != 0 then
       IO.raiseError(CellarError.ClasspathExtractionFailed(BuildToolKind.Mill, result.stderr))
     else
-      ClasspathOutputParser.parseJsonArray(result.stdout) match
+      IO.blocking(ClasspathOutputParser.parseJsonArray(result.stdout)).flatMap {
         case Left(err)    => IO.raiseError(CellarError.ClasspathExtractionFailed(BuildToolKind.Mill, err))
         case Right(paths) => IO.pure(classesDir.toList ++ paths)
+      }
 
   private def parseClassesDir(stdout: String): Option[Path] =
     val marker = "\"classes\""


### PR DESCRIPTION
## Summary
- Wrap `parseClassesDir` (calls `Files.isDirectory`) in `IO.blocking` — was running as a pure assignment on the compute pool
- Wrap `ClasspathOutputParser.parseJsonArray` call (iterates `Files.exists` over all classpath entries) in `IO.blocking` — was pattern-matched directly on the compute pool

These blocking file-system checks on the compute thread pool triggered the cats-effect CPU starvation warning:
> Your app's responsiveness to a new asynchronous event was in excess of 100 milliseconds. Your CPU is probably starving.

## Test plan
- [x] `./mill lib.compile` passes
- [x] `get --module lib cellar.build.MillBuildTool` returns results without warning
- [x] `search --module lib ProcessRunner` and `list --module lib cellar.build` work cleanly
- [x] `get-external org.typelevel:cats-effect_3:3.5.4 cats.effect.IO` works

🤖 Generated with [Claude Code](https://claude.com/claude-code)