### PR TITLE
Add Intel macOS binary to release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
             target: linux-aarch64
           - os: macos-latest
             target: macos-arm64
+          - os: macOS-15-intel
+            target: macos-x86_64
 
     runs-on: ${{ matrix.os }}
     permissions:


### PR DESCRIPTION
## Summary
- Adds `macOS-15-intel` runner to the release build matrix, producing a `macos-x86_64` native binary alongside the existing ARM64 one

Closes #18

## Test plan
- [ ] Verify the next tag push triggers the new matrix entry
- [ ] Confirm the Intel binary appears in the GitHub release assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)