### PR TITLE
Use fs2-io library for file and process handling

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -18,7 +18,7 @@ trait CommonScalaModule extends ScalaModule with ScalafixModule {
 object lib extends CommonScalaModule {
   def mvnDeps = Seq(
     mvn"org.typelevel::cats-effect:3.5.7",
-    mvn"co.fs2::fs2-core:3.11.0",
+    mvn"co.fs2::fs2-io:3.11.0",
     mvn"io.get-coursier:interface:1.0.28",
     mvn"ch.epfl.scala::tasty-query:1.7.0",
     mvn"org.scala-lang:scala3-tasty-inspector_3:3.8.1"

--- a/cli/src/cellar/cli/CellarApp.scala
+++ b/cli/src/cellar/cli/CellarApp.scala
@@ -7,7 +7,7 @@ import cellar.handlers.{DepsHandler, GetHandler, GetSourceHandler, ListHandler, 
 import com.monovore.decline.*
 import com.monovore.decline.effect.*
 import coursierapi.{MavenRepository, Repository}
-import java.nio.file.Path
+import fs2.io.file.Path
 
 object CellarApp
     extends CommandIOApp(
@@ -22,6 +22,8 @@ object CellarApp
       listSubcmd orElse listExternalSubcmd orElse
       searchSubcmd orElse searchExternalSubcmd orElse
       depsSubcmd
+
+  private given Argument[Path] = Argument[java.nio.file.Path].map(Path.fromNioPath)
 
   private val coordArg: Opts[String] =
     Opts.argument[String]("coordinate")

--- a/lib/src/cellar/CellarError.scala
+++ b/lib/src/cellar/CellarError.scala
@@ -1,7 +1,7 @@
 package cellar
 
 import cellar.build.BuildToolKind
-import java.nio.file.Path
+import fs2.io.file.Path
 
 sealed trait CellarError extends Throwable
 

--- a/lib/src/cellar/Config.scala
+++ b/lib/src/cellar/Config.scala
@@ -2,9 +2,8 @@ package cellar
 
 import cats.effect.IO
 import cats.syntax.all.*
+import fs2.io.file.{Files, Path}
 import pureconfig.*
-
-import java.nio.file.{Files, Path}
 
 case class MillConfig(binary: String) derives ConfigReader
 
@@ -18,19 +17,19 @@ object Config {
   lazy val default: IO[Config] = load(None)
 
   val defaultUserPath: Option[Path] =
-    sys.props.get("user.home").map(Path.of(_).resolve(".cellar").resolve("cellar.conf"))
-  val defaultProjectPath: Path = Path.of(".cellar").resolve("cellar.conf")
+    sys.props.get("user.home").map(Path(_).resolve(".cellar").resolve("cellar.conf"))
+  val defaultProjectPath: Path = Path(".cellar").resolve("cellar.conf")
 
   def load(path: Option[Path]): IO[Config] = {
     def load0(path: List[Path]) =
       IO.blocking {
-        path.foldLeft(ConfigSource.default)((cs, p) => ConfigSource.file(p).withFallback(cs)).loadOrThrow[Config]
+        path.foldLeft(ConfigSource.default)((cs, p) => ConfigSource.file(p.toNioPath).withFallback(cs)).loadOrThrow[Config]
       }
 
     path match
       case sp: Some[_] => load0(sp.toList)
       case None =>
         val relevantPaths = defaultUserPath.toList ++ List(defaultProjectPath)
-        relevantPaths.filterA(p => IO.blocking(Files.exists(p))).flatMap(load0)
+        relevantPaths.filterA(p => Files[IO].exists(p)).flatMap(load0)
   }
 }

--- a/lib/src/cellar/ContextResource.scala
+++ b/lib/src/cellar/ContextResource.scala
@@ -3,10 +3,10 @@ package cellar
 import cats.effect.{IO, Resource}
 import cats.syntax.monadError.*
 import coursierapi.Repository
+import fs2.io.file.Path
 import tastyquery.Classpaths.Classpath
 import tastyquery.Contexts.Context
 import tastyquery.jdk.ClasspathLoaders
-import java.nio.file.Path
 
 object ContextResource:
   def make(jars: Seq[Path], jreClasspath: Classpath): Resource[IO, (Context, Classpath)] =
@@ -28,11 +28,11 @@ object ContextResource:
     * (e.g. vendor-injected JRT modules such as the Azul CRS client).
     */
   private def readClasspathRobust(paths: List[Path]): Classpath =
-    try ClasspathLoaders.read(paths)
+    try ClasspathLoaders.read(paths.map(_.toNioPath))
     catch
       case e: MatchError =>
         val bad = paths.find { p =>
-          try { ClasspathLoaders.read(List(p)); false }
+          try { ClasspathLoaders.read(List(p.toNioPath)); false }
           catch case _: MatchError => true
         }
         bad match

--- a/lib/src/cellar/CoursierFetchClient.scala
+++ b/lib/src/cellar/CoursierFetchClient.scala
@@ -2,7 +2,8 @@ package cellar
 
 import cats.effect.IO
 import coursierapi.{Cache, Fetch, Repository}
-import java.nio.file.Path
+import fs2.io.file.Path
+
 import scala.jdk.CollectionConverters.*
 
 object CoursierFetchClient:
@@ -18,7 +19,7 @@ object CoursierFetchClient:
         .addClassifiers("sources")
         .withMainArtifacts(false)
       if extraRepositories.nonEmpty then fetch.addRepositories(extraRepositories*)
-      fetch.fetch().asScala.headOption.map(_.toPath)
+      fetch.fetch().asScala.headOption.map(file => Path.fromNioPath(file.toPath))
     }.handleError(_ => None)
 
   def fetchClasspath(
@@ -29,7 +30,7 @@ object CoursierFetchClient:
       val dep   = coord.toCoursierDependency
       val fetch = Fetch.create().addDependencies(dep).withCache(Cache.create())
       if extraRepositories.nonEmpty then fetch.addRepositories(extraRepositories*)
-      fetch.fetch().asScala.toSeq.map(_.toPath)
+      fetch.fetch().asScala.toSeq.map(file => Path.fromNioPath(file.toPath))
     }.handleErrorWith { case e: coursierapi.error.CoursierError =>
       CoordinateCompleter.suggest(coord, extraRepositories).flatMap { suggestions =>
         IO.raiseError(CellarError.CoordinateNotFound(coord, e, suggestions))

--- a/lib/src/cellar/JreClasspath.scala
+++ b/lib/src/cellar/JreClasspath.scala
@@ -19,20 +19,20 @@ object JreClasspath:
     if isNativeImage then loadBundledJre()
     else
       sys.env.get("JAVA_HOME") match
-        case Some(h) => jrtPath(Path.of(h))
+        case Some(h) => jrtPath(fs2.io.file.Path(h))
         case None =>
           IO.raiseError(new RuntimeException(
             "Could not locate JRE classpath. Set JAVA_HOME or pass --java-home pointing to a JDK installation."
           ))
 
-  def jrtPath(javaHome: Path): IO[Classpaths.Classpath] =
+  def jrtPath(javaHome: fs2.io.file.Path): IO[Classpaths.Classpath] =
     // JRT filesystem is not reliably accessible in GraalVM native image:
     // https://github.com/oracle/graal/issues/10013
     if isNativeImage then loadBundledJre()
     else
       IO.blocking {
         val jrtFsJar = javaHome.resolve("lib/jrt-fs.jar")
-        if !Files.exists(jrtFsJar) then
+        if !Files.exists(jrtFsJar.toNioPath) then
           throw new IllegalArgumentException(
             s"Not a valid JDK home (missing lib/jrt-fs.jar): $javaHome"
           )
@@ -47,7 +47,7 @@ object JreClasspath:
             provider.newFileSystem(URI.create("jrt:/"), env)
           catch case _: java.lang.reflect.InaccessibleObjectException =>
             // JVM without --add-opens: fall back to URLClassLoader
-            val cl = new URLClassLoader(Array(jrtFsJar.toUri.toURL))
+            val cl = new URLClassLoader(Array(jrtFsJar.toNioPath.toUri.toURL))
             FileSystems.newFileSystem(URI.create("jrt:/"), env, cl)
         ClasspathLoaders.read(Files.list(fs.getPath("modules")).iterator().asScala.toList)
       }

--- a/lib/src/cellar/SourceFetcher.scala
+++ b/lib/src/cellar/SourceFetcher.scala
@@ -2,7 +2,8 @@ package cellar
 
 import cats.effect.IO
 import coursierapi.Repository
-import java.nio.file.Path
+import fs2.io.file.Path
+
 import java.util.zip.ZipFile
 import scala.jdk.CollectionConverters.*
 
@@ -30,7 +31,7 @@ object SourceFetcher:
       endLine: Int
   ): Either[String, SourceResult] =
     val normalizedSource = sourceFilePath.replace('\\', '/')
-    val zip = ZipFile(jar.toFile)
+    val zip = ZipFile(jar.toNioPath.toFile)
     try
       val entry = zip.entries().asScala.find { e =>
         !e.isDirectory && normalizedSource.endsWith(e.getName)

--- a/lib/src/cellar/build/BuildFingerprint.scala
+++ b/lib/src/cellar/build/BuildFingerprint.scala
@@ -1,18 +1,23 @@
 package cellar.build
 
 import cats.effect.IO
-import java.nio.file.{Files, Path}
-import java.security.MessageDigest
+import cats.syntax.all.*
+import fs2.Chunk
+import fs2.io.file.{Files, Path}
+import fs2.hashing.*
+
+import java.nio.charset.StandardCharsets
 
 object BuildFingerprint:
   def compute(files: List[Path], module: String): IO[String] =
-    IO.blocking {
-      val digest = MessageDigest.getInstance("SHA-256")
-      digest.update(module.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-      files.sorted.foreach { path =>
-        if Files.exists(path) then
-          digest.update(path.toString.getBytes(java.nio.charset.StandardCharsets.UTF_8))
-          digest.update(Files.readAllBytes(path))
-      }
-      digest.digest().map(b => f"$b%02x").mkString
+    Hashing[IO].hasher(HashAlgorithm.SHA256).use { hasher =>
+      for
+        _ <- hasher.update(Chunk.array(module.getBytes(StandardCharsets.UTF_8)))
+        _ <- fs2.Stream.emits(files.sortBy(_.toNioPath))
+          .evalFilter(Files[IO].exists)
+          .evalTap(path => hasher.update(Chunk.array(path.toString.getBytes(StandardCharsets.UTF_8))))
+          .flatMap(path => Files[IO].readAll(path).through(hasher.update))
+          .compile.drain
+        hash <- hasher.hash
+      yield hash.bytes.foldMap(b => f"$b%02x")
     }

--- a/lib/src/cellar/build/BuildTool.scala
+++ b/lib/src/cellar/build/BuildTool.scala
@@ -2,13 +2,13 @@ package cellar.build
 
 import cats.effect.IO
 import cellar.CellarError
-import java.nio.file.Path
+import fs2.io.file.Path
 
 trait BuildTool:
   def kind: BuildToolKind
   def compile(module: Option[String]): IO[Unit]
   def extractClasspath(module: Option[String]): IO[List[Path]]
-  def fingerprintFiles(): IO[List[Path]]
+  def fingerprintFiles: IO[List[Path]]
 
   protected def requireModule(module: Option[String]): IO[String] =
     module match

--- a/lib/src/cellar/build/BuildToolDetector.scala
+++ b/lib/src/cellar/build/BuildToolDetector.scala
@@ -11,14 +11,15 @@ object BuildToolDetector:
   private val millMarkers = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml")
 
   /** Detect the build tool kind from marker files only (no binary check). */
-  def detectKind(dir: Path): IO[BuildToolKind] =
-    {
-      val millMarker = millMarkers.findM(m => Files[IO].exists(dir.resolve(m)))
-      val hasSbt = Files[IO].exists(dir.resolve("build.sbt"))
+  def detectKind(dir: Path): IO[BuildToolKind] = {
+    val hasMill = millMarkers.existsM(m => Files[IO].exists(dir.resolve(m)))
+    val hasSbt = Files[IO].exists(dir.resolve("build.sbt"))
+    val hasScalaCli = Files[IO].isDirectory(dir.resolve(".scala-build"))
 
-      millMarker.map(_.isDefined).ifM(
-        IO.pure(BuildToolKind.Mill),
-        hasSbt.ifF(BuildToolKind.Sbt, BuildToolKind.ScalaCli) /* scala-cli is also fallback */
-      )
-    }
+    BuildToolKind.values.toList.findM { // sequentially check each until one is true
+      case BuildToolKind.Mill => hasMill
+      case BuildToolKind.Sbt => hasSbt
+      case BuildToolKind.ScalaCli => hasScalaCli
+    }.map(_.getOrElse(BuildToolKind.ScalaCli)) // default to Scala CLI if none was found
+  }
 

--- a/lib/src/cellar/build/BuildToolDetector.scala
+++ b/lib/src/cellar/build/BuildToolDetector.scala
@@ -1,7 +1,8 @@
 package cellar.build
 
 import cats.effect.IO
-import java.nio.file.{Files, Path}
+import cats.syntax.all.*
+import fs2.io.file.{Files, Path}
 
 enum BuildToolKind:
   case Mill, Sbt, ScalaCli
@@ -11,14 +12,13 @@ object BuildToolDetector:
 
   /** Detect the build tool kind from marker files only (no binary check). */
   def detectKind(dir: Path): IO[BuildToolKind] =
-    IO.blocking {
-      val millMarker = millMarkers.find(m => Files.exists(dir.resolve(m)))
-      val hasSbt = Files.exists(dir.resolve("build.sbt"))
-      val hasScalaBuild = Files.isDirectory(dir.resolve(".scala-build"))
+    {
+      val millMarker = millMarkers.findM(m => Files[IO].exists(dir.resolve(m)))
+      val hasSbt = Files[IO].exists(dir.resolve("build.sbt"))
 
-      if millMarker.isDefined then BuildToolKind.Mill
-      else if hasSbt then BuildToolKind.Sbt
-      else if hasScalaBuild then BuildToolKind.ScalaCli
-      else BuildToolKind.ScalaCli // fallback
+      millMarker.map(_.isDefined).ifM(
+        IO.pure(BuildToolKind.Mill),
+        hasSbt.ifF(BuildToolKind.Sbt, BuildToolKind.ScalaCli) /* scala-cli is also fallback */
+      )
     }
 

--- a/lib/src/cellar/build/ClasspathCache.scala
+++ b/lib/src/cellar/build/ClasspathCache.scala
@@ -1,30 +1,28 @@
 package cellar.build
 
 import cats.effect.IO
-import java.nio.file.{Files, Path, StandardCopyOption}
+import cats.syntax.all.*
+import fs2.Stream
+import fs2.io.file.{CopyFlag, CopyFlags, Files, Path}
 
 class ClasspathCache(projectDir: Path):
   private val cacheDir = projectDir.resolve(".cellar").resolve("cache")
 
   def get(hash: String): IO[Option[List[Path]]] =
-    IO.blocking {
-      val file = cacheDir.resolve(s"$hash.txt")
-      if !Files.exists(file) then None
-      else
-        val paths = Files.readString(file).linesIterator
-          .filter(_.nonEmpty)
-          .map(Path.of(_))
-          .toList
-        // Validate all paths still exist
-        if paths.forall(Files.exists(_)) then Some(paths)
-        else None
+    val file = cacheDir.resolve(s"$hash.txt")
+    Files[IO].exists(file).flatMap {
+      case true =>
+        for
+          paths <- Files[IO].readUtf8Lines(file).filter(_.nonEmpty).map(Path(_)).compile.toList
+          allExist <- paths.forallM(Files[IO].exists)
+        yield Option.when(allExist)(paths)
+      case false => IO.pure(None)
     }
 
-  def put(hash: String, paths: List[Path]): IO[Unit] =
-    IO.blocking {
-      Files.createDirectories(cacheDir)
-      val file = cacheDir.resolve(s"$hash.txt")
-      val tmp = cacheDir.resolve(s"$hash.tmp")
-      Files.writeString(tmp, paths.map(_.toString).mkString("\n") + "\n")
-      Files.move(tmp, file, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE)
-    }
+  def put(hash: String, paths: List[Path]): IO[Unit] = for {
+    _ <- Files[IO].createDirectories(cacheDir)
+    file = cacheDir.resolve(s"$hash.txt")
+    tmp = cacheDir.resolve(s"$hash.tmp")
+    _ <- Stream(paths.map(_.toString).mkString("\n") + "\n").through(Files[IO].writeUtf8(tmp)).compile.drain
+    _ <- Files[IO].move(tmp, file, CopyFlags(CopyFlag.ReplaceExisting, CopyFlag.AtomicMove))
+  } yield ()

--- a/lib/src/cellar/build/ClasspathOutputParser.scala
+++ b/lib/src/cellar/build/ClasspathOutputParser.scala
@@ -1,17 +1,19 @@
 package cellar.build
 
-import java.nio.file.{Files, Path}
+import cats.effect.IO
+import cats.syntax.all._
+import fs2.io.file.{Files, Path}
 
 object ClasspathOutputParser:
 
   /** Parse Mill's JSON array output: `["ref:hash:/path", "/path2"]` */
-  def parseJsonArray(input: String, checkExists: Boolean = true): Either[String, List[Path]] =
+  def parseJsonArray(input: String, checkExists: Boolean = true): IO[Either[String, List[Path]]] =
     val trimmed = input.trim
     if !trimmed.startsWith("[") || !trimmed.endsWith("]") then
-      return Left(s"Expected JSON array but got: ${trimmed.take(100)}")
+      return IO.pure(Left(s"Expected JSON array but got: ${trimmed.take(100)}"))
 
     val inner = trimmed.substring(1, trimmed.length - 1).trim
-    if inner.isEmpty then return Left("Build tool produced an empty classpath.")
+    if inner.isEmpty then return IO.pure(Left("Build tool produced an empty classpath."))
 
     val entries = inner.split(",").map(_.trim.stripPrefix("\"").stripSuffix("\"")).toList
     val paths = entries.map { entry =>
@@ -20,12 +22,14 @@ object ClasspathOutputParser:
       val path = entry.lastIndexOf(":/") match
         case -1  => entry // plain path
         case idx => entry.substring(idx + 1) // strip prefix up to the path
-      Path.of(path)
+      Path(path)
     }
 
-    val filtered = if checkExists then paths.filter(p => Files.exists(p)) else paths
-    if filtered.isEmpty then Left("Build tool produced an empty classpath (all paths filtered).")
-    else Right(filtered)
+    val filtered = if checkExists then paths.filterA(p => Files[IO].exists(p)) else IO.pure(paths)
+    filtered.map {
+      case Nil => Left("Build tool produced an empty classpath (all paths filtered).")
+      case filtered => Right(filtered)
+    }
 
   /** Parse colon-separated classpath output (sbt, scala-cli) */
   def parseColonSeparated(input: String): Either[String, List[Path]] =
@@ -36,4 +40,4 @@ object ClasspathOutputParser:
       .toList
 
     if entries.isEmpty then Left("Build tool produced an empty classpath.")
-    else Right(entries.map(Path.of(_)))
+    else Right(entries.map(Path(_)))

--- a/lib/src/cellar/build/MillBuildTool.scala
+++ b/lib/src/cellar/build/MillBuildTool.scala
@@ -1,16 +1,17 @@
 package cellar.build
 
 import cats.effect.IO
+import cats.syntax.all._
 import cellar.CellarError
 import cellar.process.ProcessRunner
-import java.nio.file.{Files, Path}
+import fs2.io.file.{Files, Path}
 
 class MillBuildTool(cwd: Path, binary: String = "./mill") extends BuildTool:
   def kind: BuildToolKind = BuildToolKind.Mill
 
   def compile(module: Option[String]): IO[Unit] =
     requireModule(module).flatMap { mod =>
-      ProcessRunner.run(List(binary, s"$mod.compile"), Some(cwd)).flatMap { result =>
+      ProcessRunner.run(binary, List(s"$mod.compile"), Some(cwd)).flatMap { result =>
         if result.exitCode == 0 then IO.unit
         else IO.raiseError(CellarError.CompilationFailed(BuildToolKind.Mill, result.stderr))
       }
@@ -19,10 +20,10 @@ class MillBuildTool(cwd: Path, binary: String = "./mill") extends BuildTool:
   def extractClasspath(module: Option[String]): IO[List[Path]] =
     requireModule(module).flatMap { mod =>
       for
-        compileResult <- ProcessRunner.run(List(binary, "show", s"$mod.compile"), Some(cwd))
+        compileResult <- ProcessRunner.run(binary, List("show", s"$mod.compile"), Some(cwd))
         _ <- checkCompileResult(compileResult, mod)
-        classesDir <- IO.blocking(parseClassesDir(compileResult.stdout))
-        cpResult <- ProcessRunner.run(List(binary, "show", s"$mod.compileClasspath"), Some(cwd))
+        classesDir <- parseClassesDir(compileResult.stdout)
+        cpResult <- ProcessRunner.run(binary, List("show", s"$mod.compileClasspath"), Some(cwd))
         paths <- parseClasspathResult(cpResult, classesDir)
       yield paths
     }
@@ -38,55 +39,51 @@ class MillBuildTool(cwd: Path, binary: String = "./mill") extends BuildTool:
     if result.exitCode != 0 then
       IO.raiseError(CellarError.ClasspathExtractionFailed(BuildToolKind.Mill, result.stderr))
     else
-      IO.blocking(ClasspathOutputParser.parseJsonArray(result.stdout)).flatMap {
+      ClasspathOutputParser.parseJsonArray(result.stdout).flatMap {
         case Left(err)    => IO.raiseError(CellarError.ClasspathExtractionFailed(BuildToolKind.Mill, err))
         case Right(paths) => IO.pure(classesDir.toList ++ paths)
       }
 
-  private def parseClassesDir(stdout: String): Option[Path] =
+  private def parseClassesDir(stdout: String): IO[Option[Path]] =
     val marker = "\"classes\""
     stdout.indexOf(marker) match
-      case -1 => None
+      case -1 => IO.pure(None)
       case idx =>
         val afterColon = stdout.indexOf(':', idx + marker.length)
-        if afterColon == -1 then None
+        if afterColon == -1 then IO.pure(None)
         else
           val valueStart = stdout.indexOf('"', afterColon + 1)
           val valueEnd = stdout.indexOf('"', valueStart + 1)
-          if valueStart == -1 || valueEnd == -1 then None
+          if valueStart == -1 || valueEnd == -1 then IO.pure(None)
           else
             val raw = stdout.substring(valueStart + 1, valueEnd)
             // Handle ref: or qref: prefixed paths by finding ":/" before the absolute path
             val path = raw.lastIndexOf(":/") match
               case -1  => raw
               case i   => raw.substring(i + 1)
-            Some(Path.of(path)).filter(Files.isDirectory(_))
+            Path(path).some.filterA(Files[IO].isDirectory(_))
 
-  def fingerprintFiles(): IO[List[Path]] =
-    IO.blocking {
-      if Files.isDirectory(cwd.resolve(".git")) then fingerprintFromGit()
-      else fingerprintFromDisk()
+  def fingerprintFiles: IO[List[Path]] =
+    Files[IO].isDirectory(cwd.resolve(".git")).ifM(
+      ifTrue = fingerprintFromGit,
+      ifFalse = fingerprintFromDisk
+    )
+
+  private def fingerprintFromGit: IO[List[Path]] =
+    val patterns = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", "mill-build/**", ".mill-version")
+    ProcessRunner.run("git", "ls-files" :: patterns, Some(cwd)).flatMap { result =>
+      if result.exitCode == 0 then
+        IO.pure(result.stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList)
+      else
+        fingerprintFromDisk
     }
 
-  private def fingerprintFromGit(): List[Path] =
-    val patterns = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", "mill-build/**", ".mill-version")
-    val result = new ProcessBuilder(("git" :: "ls-files" :: patterns)*)
-      .directory(cwd.toFile)
-      .start()
-    val stdout = new String(result.getInputStream.readAllBytes())
-    if result.waitFor() == 0 then
-      stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList
-    else
-      fingerprintFromDisk()
-
-  private def fingerprintFromDisk(): List[Path] =
+  private def fingerprintFromDisk: IO[List[Path]] =
     val candidates = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", ".mill-version")
-    val files = candidates.map(cwd.resolve).filter(Files.exists(_))
+    val files = candidates.map(cwd.resolve).filterA(Files[IO].exists(_))
     val millBuildDir = cwd.resolve("mill-build")
-    val millBuildFiles =
-      if Files.isDirectory(millBuildDir) then
-        val stream = Files.list(millBuildDir)
-        try stream.toArray.map(_.asInstanceOf[Path]).toList
-        finally stream.close()
-      else Nil
-    files ++ millBuildFiles
+    val millBuildFiles = Files[IO].isDirectory(millBuildDir).flatMap {
+        case true  => Files[IO].list(millBuildDir).compile.toList
+        case false => IO.pure(Nil)
+    }
+    (files, millBuildFiles).parMapN(_ ++ _)

--- a/lib/src/cellar/build/ProjectClasspathProvider.scala
+++ b/lib/src/cellar/build/ProjectClasspathProvider.scala
@@ -2,7 +2,7 @@ package cellar.build
 
 import cats.effect.{IO, Resource}
 import cellar.ContextResource
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Classpaths.Classpath
 import tastyquery.Contexts.Context
 
@@ -32,7 +32,7 @@ object ProjectClasspathProvider:
     val moduleKey = module.getOrElse("")
 
     for
-      fingerFiles <- buildTool.fingerprintFiles()
+      fingerFiles <- buildTool.fingerprintFiles
       hash        <- BuildFingerprint.compute(fingerFiles, moduleKey)
       cached      <- cache.get(hash)
       paths <- cached match

--- a/lib/src/cellar/build/SbtBuildTool.scala
+++ b/lib/src/cellar/build/SbtBuildTool.scala
@@ -1,24 +1,26 @@
 package cellar.build
 
 import cats.effect.IO
+import cats.syntax.all._
 import cellar.CellarError
 import cellar.process.ProcessRunner
-import java.nio.file.{Files, Path}
+import fs2.io.file.{Files, Path}
 
 class SbtBuildTool(cwd: Path) extends BuildTool:
   def kind: BuildToolKind = BuildToolKind.Sbt
 
   def compile(module: Option[String]): IO[Unit] =
     requireModule(module).flatMap { mod =>
-      ProcessRunner.run(List("sbt", "--batch", s"$mod/compile"), Some(cwd)).flatMap { result =>
-        if result.exitCode == 0 then IO.unit
-        else IO.raiseError(CellarError.CompilationFailed(BuildToolKind.Sbt, extractErrors(result.stdout, result.stderr)))
+      ProcessRunner.run("sbt", List("--batch", s"$mod/compile"), Some(cwd)).flatMap { result =>
+        IO.raiseUnless(result.exitCode == 0)(
+          CellarError.CompilationFailed(BuildToolKind.Sbt, extractErrors(result.stdout, result.stderr))
+        )
       }
     }
 
   def extractClasspath(module: Option[String]): IO[List[Path]] =
     requireModule(module).flatMap { mod =>
-      ProcessRunner.run(List("sbt", "--batch", s"export $mod/Compile/fullClasspath"), Some(cwd)).flatMap { result =>
+      ProcessRunner.run("sbt", List("--batch", s"export $mod/Compile/fullClasspath"), Some(cwd)).flatMap { result =>
         if result.exitCode != 0 then
           IO.raiseError(CellarError.CompilationFailed(BuildToolKind.Sbt, extractErrors(result.stdout, result.stderr)))
         else
@@ -40,35 +42,30 @@ class SbtBuildTool(cwd: Path) extends BuildTool:
       }
     }
 
-  def fingerprintFiles(): IO[List[Path]] =
-    IO.blocking {
-      if Files.isDirectory(cwd.resolve(".git")) then fingerprintFromGit()
-      else fingerprintFromDisk()
+  def fingerprintFiles: IO[List[Path]] =
+    Files[IO].isDirectory(cwd.resolve(".git")).ifM(
+      ifTrue = fingerprintFromGit,
+      ifFalse = fingerprintFromDisk
+    )
+
+  private def fingerprintFromGit: IO[List[Path]] =
+    val patterns = List("build.sbt", "project/*.sbt", "project/*.scala", "project/build.properties")
+    ProcessRunner.run("git", "ls-files" :: patterns, Some(cwd)).flatMap {
+      case result if result.exitCode == 0 =>
+        IO.pure(result.stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList)
+      case _ => fingerprintFromDisk
     }
 
-  private def fingerprintFromGit(): List[Path] =
-    val patterns = List("build.sbt", "project/*.sbt", "project/*.scala", "project/build.properties")
-    val result = new ProcessBuilder(("git" :: "ls-files" :: patterns)*)
-      .directory(cwd.toFile)
-      .start()
-    val stdout = new String(result.getInputStream.readAllBytes())
-    if result.waitFor() == 0 then
-      stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList
-    else
-      fingerprintFromDisk()
-
-  private def fingerprintFromDisk(): List[Path] =
+  private def fingerprintFromDisk: IO[List[Path]] =
     val candidates = List("build.sbt", "project/build.properties", "project/plugins.sbt")
-    val files = candidates.map(cwd.resolve).filter(Files.exists(_))
+    val files = candidates.map(cwd.resolve).filterA(Files[IO].exists(_))
     val projectDir = cwd.resolve("project")
     val projectFiles =
-      if Files.isDirectory(projectDir) then
-        val stream = Files.list(projectDir)
-        try stream.toArray.map(_.asInstanceOf[Path]).toList
-          .filter(p => p.toString.endsWith(".sbt") || p.toString.endsWith(".scala"))
-        finally stream.close()
-      else Nil
-    (files ++ projectFiles).distinct
+      Files[IO].isDirectory(projectDir).ifM(
+        ifTrue = Files[IO].list(projectDir, "*.{sbt,scala}").compile.toList,
+        ifFalse = IO.pure(Nil)
+      )
+    (files, projectFiles).parMapN((f, pf) => (f ++ pf).distinct)
 
   private def extractErrors(stdout: String, stderr: String): String =
     val errorLines = stdout.linesIterator.filter(_.startsWith("[error]")).mkString("\n")

--- a/lib/src/cellar/build/ScalaCliBuildTool.scala
+++ b/lib/src/cellar/build/ScalaCliBuildTool.scala
@@ -3,21 +3,21 @@ package cellar.build
 import cats.effect.IO
 import cellar.CellarError
 import cellar.process.ProcessRunner
-import java.nio.file.Path
+import fs2.io.file.Path
 
 class ScalaCliBuildTool(cwd: Path) extends BuildTool:
   def kind: BuildToolKind = BuildToolKind.ScalaCli
 
   def compile(module: Option[String]): IO[Unit] =
     rejectModule(module) >>
-      ProcessRunner.run(List("scala-cli", "compile", "."), Some(cwd)).flatMap { result =>
+      ProcessRunner.run("scala-cli", List("compile", "."), Some(cwd)).flatMap { result =>
         if result.exitCode == 0 then IO.unit
         else IO.raiseError(CellarError.CompilationFailed(BuildToolKind.ScalaCli, result.stderr))
       }
 
   def extractClasspath(module: Option[String]): IO[List[Path]] =
     rejectModule(module) >>
-      ProcessRunner.run(List("scala-cli", "compile", "--print-classpath", "."), Some(cwd)).flatMap { result =>
+      ProcessRunner.run("scala-cli", List("compile", "--print-classpath", "."), Some(cwd)).flatMap { result =>
         if result.exitCode != 0 then
           IO.raiseError(CellarError.CompilationFailed(BuildToolKind.ScalaCli, result.stderr))
         else
@@ -26,7 +26,7 @@ class ScalaCliBuildTool(cwd: Path) extends BuildTool:
             case Right(paths) => IO.pure(paths)
       }
 
-  def fingerprintFiles(): IO[List[Path]] = IO.pure(Nil)
+  def fingerprintFiles: IO[List[Path]] = IO.pure(Nil)
 
   private def rejectModule(module: Option[String]): IO[Unit] =
     module match

--- a/lib/src/cellar/handlers/GetHandler.scala
+++ b/lib/src/cellar/handlers/GetHandler.scala
@@ -4,7 +4,7 @@ import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
 import coursierapi.Repository
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Classpaths.Classpath
 import tastyquery.Contexts.Context
 import tastyquery.Symbols.Symbol
@@ -36,10 +36,10 @@ object GetHandler:
   )(using Context, Console[IO]): IO[ExitCode] =
     SymbolResolver.resolve(fqn).flatMap {
       case LookupResult.Found(symbols) =>
-        val jars = classpath.filter(_.toString.endsWith(".jar")).map(e => Path.of(e.toString)).toSeq
+        val jars = classpath.filter(_.toString.endsWith(".jar")).map(e => Path(e.toString)).toSeq
         for
           _         <- warnShadedDuplicate(fqn, classpath)
-          docstring <- coord.fold(IO.pure(Option.empty[String]))(c => IO.blocking(DocstringExtractor.extract(jars, c, fqn)))
+          docstring <- coord.fold(IO.pure(Option.empty[String]))(c => IO.blocking(DocstringExtractor.extract(jars.map(_.toNioPath), c, fqn)))
           formatted <- IO.blocking(GetFormatter.formatGetResult(fqn, symbols, docstring))
           _         <- Console[IO].println(formatted)
           _         <- warnScala2(symbols)
@@ -90,8 +90,8 @@ object GetHandler:
     }
     if containing.size > 1 then
       try
-        val first = Path.of(containing(0).toString)
-        val dup   = Path.of(containing(1).toString)
+        val first = Path(containing(0).toString)
+        val dup   = Path(containing(1).toString)
         Some(CellarError.ShadedDuplicate(fqn, first, dup))
       catch case _: Exception => None
     else None

--- a/lib/src/cellar/handlers/GetSourceHandler.scala
+++ b/lib/src/cellar/handlers/GetSourceHandler.scala
@@ -4,7 +4,7 @@ import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
 import coursierapi.Repository
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Contexts.Context
 import tastyquery.SourceLanguage
 import tastyquery.Symbols.TermOrTypeSymbol

--- a/lib/src/cellar/handlers/ListHandler.scala
+++ b/lib/src/cellar/handlers/ListHandler.scala
@@ -5,7 +5,7 @@ import cats.effect.std.Console
 import cats.syntax.all.*
 import cellar.*
 import coursierapi.Repository
-import java.nio.file.Path
+import fs2.io.file.Path
 
 object ListHandler:
   def run(

--- a/lib/src/cellar/handlers/ProjectGetHandler.scala
+++ b/lib/src/cellar/handlers/ProjectGetHandler.scala
@@ -3,7 +3,7 @@ package cellar.handlers
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Contexts.Context
 
 object ProjectGetHandler:

--- a/lib/src/cellar/handlers/ProjectHandler.scala
+++ b/lib/src/cellar/handlers/ProjectHandler.scala
@@ -18,12 +18,12 @@ object ProjectHandler:
     val program =
       for
         jreClasspath <- javaHome.fold(JreClasspath.jrtPath())(JreClasspath.jrtPath)
-        workingDir   <- cwd.fold(IO.blocking(Path(System.getProperty("user.dir"))))(IO.pure)
+        workingDir   = cwd.getOrElse(Path(System.getProperty("user.dir")))
         result       <- build.ProjectClasspathProvider.provide(workingDir, module, jreClasspath, noCache, config).use { (ctx, classpath) =>
           body(ctx, classpath, jreClasspath)
         }
       yield result
 
-    program.handleErrorWith { case e: Throwable =>
+    program.handleErrorWith { (e: Throwable) =>
       Console[IO].errorln(e.getMessage).as(ExitCode.Error)
     }

--- a/lib/src/cellar/handlers/ProjectHandler.scala
+++ b/lib/src/cellar/handlers/ProjectHandler.scala
@@ -3,7 +3,7 @@ package cellar.handlers
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Classpaths.Classpath
 import tastyquery.Contexts.Context
 
@@ -18,7 +18,7 @@ object ProjectHandler:
     val program =
       for
         jreClasspath <- javaHome.fold(JreClasspath.jrtPath())(JreClasspath.jrtPath)
-        workingDir   <- cwd.fold(IO.blocking(Path.of(System.getProperty("user.dir"))))(IO.pure)
+        workingDir   <- cwd.fold(IO.blocking(Path(System.getProperty("user.dir"))))(IO.pure)
         result       <- build.ProjectClasspathProvider.provide(workingDir, module, jreClasspath, noCache, millBinary).use { (ctx, classpath) =>
           body(ctx, classpath, jreClasspath)
         }

--- a/lib/src/cellar/handlers/ProjectListHandler.scala
+++ b/lib/src/cellar/handlers/ProjectListHandler.scala
@@ -3,7 +3,7 @@ package cellar.handlers
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Contexts.Context
 
 object ProjectListHandler:

--- a/lib/src/cellar/handlers/ProjectSearchHandler.scala
+++ b/lib/src/cellar/handlers/ProjectSearchHandler.scala
@@ -3,7 +3,7 @@ package cellar.handlers
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import cellar.*
-import java.nio.file.Path
+import fs2.io.file.Path
 import tastyquery.Contexts.Context
 
 object ProjectSearchHandler:

--- a/lib/src/cellar/handlers/SearchHandler.scala
+++ b/lib/src/cellar/handlers/SearchHandler.scala
@@ -5,7 +5,7 @@ import cats.effect.std.Console
 import cats.syntax.all.*
 import cellar.*
 import coursierapi.Repository
-import java.nio.file.Path
+import fs2.io.file.Path
 
 object SearchHandler:
   def run(

--- a/lib/src/cellar/process/ProcessRunner.scala
+++ b/lib/src/cellar/process/ProcessRunner.scala
@@ -18,8 +18,7 @@ object ProcessRunner:
         process.stderr.through(fs2.text.utf8.decode).compile.string
       ).parMapN(ProcessResult.apply)
     }.adaptError { case e: java.io.IOException =>
-      val cmd = command.headOption.getOrElse("")
       val detail = Option(e.getMessage).getOrElse("I/O error")
-      new RuntimeException(s"Failed to start '$cmd': $detail", e)
+      new RuntimeException(s"Failed to start '$command': $detail", e)
     }
   }

--- a/lib/src/cellar/process/ProcessRunner.scala
+++ b/lib/src/cellar/process/ProcessRunner.scala
@@ -2,31 +2,24 @@ package cellar.process
 
 import cats.effect.IO
 import cats.syntax.all.*
-import java.nio.file.Path
+import fs2.io.file.Path
+import fs2.io.process.*
 
 final case class ProcessResult(exitCode: Int, stdout: String, stderr: String)
 
 object ProcessRunner:
-  def run(command: List[String], workingDir: Option[Path] = None): IO[ProcessResult] =
-    IO.blocking {
-      val builder = new ProcessBuilder(command*)
-      workingDir.foreach(dir => builder.directory(dir.toFile))
-      builder.redirectErrorStream(false)
-      val process = builder.start()
-      try
-        // Drain stderr on a separate thread to avoid pipe buffer deadlock
-        @volatile var stderr = ""
-        val stderrDrainer = new Thread(() =>
-          stderr = new String(process.getErrorStream.readAllBytes())
-        )
-        stderrDrainer.start()
-        val stdout = new String(process.getInputStream.readAllBytes())
-        stderrDrainer.join()
-        val exitCode = process.waitFor()
-        ProcessResult(exitCode, stdout, stderr)
-      finally process.destroyForcibly()
+  def run(command: String, args: List[String], workingDir: Option[Path] = None): IO[ProcessResult] = {
+    val builder = ProcessBuilder(command, args)
+    val withWorkingDir = workingDir.fold(builder)(dir => builder.withWorkingDirectory(dir))
+    withWorkingDir.spawn[IO].use { process =>
+      (
+        process.exitValue,
+        process.stdout.through(fs2.text.utf8.decode).compile.string,
+        process.stderr.through(fs2.text.utf8.decode).compile.string
+      ).parMapN(ProcessResult.apply)
     }.adaptError { case e: java.io.IOException =>
       val cmd = command.headOption.getOrElse("")
       val detail = Option(e.getMessage).getOrElse("I/O error")
       new RuntimeException(s"Failed to start '$cmd': $detail", e)
     }
+  }

--- a/lib/test/src/cellar/CellarErrorTest.scala
+++ b/lib/test/src/cellar/CellarErrorTest.scala
@@ -39,8 +39,8 @@ class CellarErrorTest extends munit.FunSuite:
     assert(e.getMessage.nonEmpty)
 
   test("ShadedDuplicate getMessage contains both JAR paths"):
-    val p1 = java.nio.file.Path.of("/tmp/a.jar")
-    val p2 = java.nio.file.Path.of("/tmp/b.jar")
+    val p1 = fs2.io.file.Path("/tmp/a.jar")
+    val p2 = fs2.io.file.Path("/tmp/b.jar")
     val e  = CellarError.ShadedDuplicate("com.Foo", p1, p2)
     assert(e.getMessage.contains("/tmp/a.jar"))
     assert(e.getMessage.contains("/tmp/b.jar"))

--- a/lib/test/src/cellar/CoursierFetchClientTest.scala
+++ b/lib/test/src/cellar/CoursierFetchClientTest.scala
@@ -13,7 +13,7 @@ class CoursierFetchClientTest extends CatsEffectSuite:
     ).map { paths =>
       assert(paths.nonEmpty, "Expected at least one JAR")
       paths.foreach { p =>
-        assert(java.nio.file.Files.exists(p), s"Path does not exist: $p")
+        assert(java.nio.file.Files.exists(p.toNioPath), s"Path does not exist: $p")
         assert(p.toString.endsWith(".jar"), s"Expected .jar, got: $p")
       }
     }
@@ -25,7 +25,7 @@ class CoursierFetchClientTest extends CatsEffectSuite:
       Seq(TestFixtures.localM2Repo)
     ).map { paths =>
       assert(paths.nonEmpty)
-      assert(paths.forall(p => java.nio.file.Files.exists(p)))
+      assert(paths.forall(p => java.nio.file.Files.exists(p.toNioPath)))
     }
 
   test("fetchClasspath with non-existent version raises CoordinateNotFound with suggestions"):

--- a/lib/test/src/cellar/JreClasspathTest.scala
+++ b/lib/test/src/cellar/JreClasspathTest.scala
@@ -1,8 +1,8 @@
 package cellar
 
 import cats.effect.IO
+import fs2.io.file.{Files, Path}
 import munit.CatsEffectSuite
-import java.nio.file.{Files, Path}
 
 class JreClasspathTest extends CatsEffectSuite:
 
@@ -13,23 +13,24 @@ class JreClasspathTest extends CatsEffectSuite:
     }
 
   test("one-arg jrtPath with current java.home succeeds"):
-    val javaHome = Path.of(System.getProperty("java.home"))
+    val javaHome = Path(System.getProperty("java.home"))
     JreClasspath.jrtPath(javaHome).map { classpath =>
       assert(classpath.nonEmpty)
     }
 
   test("one-arg jrtPath with non-existent path raises error"):
-    val badPath = Path.of("/tmp/nonexistent-jdk-home-12345")
+    val badPath = Path("/tmp/nonexistent-jdk-home-12345")
     JreClasspath.jrtPath(badPath).attempt.map { result =>
       assert(result.isLeft, "Expected an error for non-existent path")
     }
 
   test("one-arg jrtPath with plain directory (no jrt-fs.jar) raises IllegalArgumentException"):
-    val tmpDir = Files.createTempDirectory("cellar-test")
-    JreClasspath.jrtPath(tmpDir).attempt.map { result =>
-      assert(result.isLeft)
-      result.left.foreach {
-        case _: IllegalArgumentException => ()
-        case e                           => fail(s"Expected IllegalArgumentException, got ${e.getClass}")
+    Files[IO].tempDirectory.use { tmpDir =>
+      JreClasspath.jrtPath(tmpDir).attempt.map { result =>
+        assert(result.isLeft)
+        result.left.foreach {
+          case _: IllegalArgumentException => ()
+          case e => fail(s"Expected IllegalArgumentException, got ${e.getClass}")
+        }
       }
-    }.guarantee(IO.blocking(Files.deleteIfExists(tmpDir)).void)
+    }

--- a/lib/test/src/cellar/ProjectAwareIntegrationTest.scala
+++ b/lib/test/src/cellar/ProjectAwareIntegrationTest.scala
@@ -2,7 +2,10 @@ package cellar
 
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
+import cats.syntax.all.*
+import cellar.process.ProcessRunner
 import munit.CatsEffectSuite
+
 import java.nio.file.Files
 import fs2.io.file.{Files => Fs2Files, Path}
 
@@ -18,13 +21,11 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   private lazy val millBinary: String =
     Option(System.getProperty("cellar.test.millBinary")).getOrElse("mill")
 
-  private def isOnPath(binary: String): Boolean =
-    val result = new ProcessBuilder("which", binary).start()
-    result.getInputStream.readAllBytes()
-    result.waitFor() == 0
+  private def isOnPath(binary: String): IO[Boolean] =
+    ProcessRunner.run("which", List(binary)).map(_.exitCode == 0).handleError(_ => false)
 
-  private def isBinaryAvailable(binary: String): Boolean =
-    Fs2Files[IO].isRegularFile(Path(binary)) || isOnPath(binary)
+  private def isBinaryAvailable(binary: String): IO[Boolean] =
+    (Fs2Files[IO].isRegularFile(Path(binary)), isOnPath(binary)).mapN(_ || _)
 
   private def withTempDir(test: Path => IO[Unit]): IO[Unit] =
     Fs2Files[IO].tempDirectory.use(test)
@@ -287,7 +288,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   // --- End-to-end scala-cli tests (requires scala-cli on PATH) ---
 
   test("E2E scala-cli: get resolves project symbol"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -306,7 +307,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E scala-cli: get resolves symbol from dependency"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -326,7 +327,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E scala-cli: list lists members of project class"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -347,7 +348,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E scala-cli: search finds symbols across project"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -365,7 +366,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E scala-cli: --module produces error"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -381,7 +382,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E scala-cli: compilation failure surfaces build tool error"):
-    assume(isOnPath("scala-cli"), "scala-cli not on PATH")
+    isOnPath("scala-cli").map(assume(_, "scala-cli not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -401,7 +402,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   // --- End-to-end Mill tests (requires mill on PATH) ---
 
   test("E2E Mill: get resolves project symbol"):
-    assume(isBinaryAvailable(millBinary), s"$millBinary not found")
+    isBinaryAvailable(millBinary).map(assume(_, s"$millBinary not found")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -432,7 +433,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E Mill: --module required"):
-    assume(isBinaryAvailable(millBinary), s"$millBinary not found")
+    isBinaryAvailable(millBinary).map(assume(_, s"$millBinary not found")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -446,7 +447,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   // --- End-to-end sbt tests (requires sbt on PATH) ---
 
   test("E2E sbt: get resolves project symbol"):
-    assume(isOnPath("sbt"), "sbt not on PATH")
+    isOnPath("sbt").map(assume(_, "sbt not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
@@ -474,7 +475,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     }
 
   test("E2E sbt: --module required"):
-    assume(isOnPath("sbt"), "sbt not on PATH")
+    isOnPath("sbt").map(assume(_, "sbt not on PATH")) >>
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console

--- a/lib/test/src/cellar/ProjectAwareIntegrationTest.scala
+++ b/lib/test/src/cellar/ProjectAwareIntegrationTest.scala
@@ -3,7 +3,8 @@ package cellar
 import cats.effect.{ExitCode, IO}
 import cats.effect.std.Console
 import munit.CatsEffectSuite
-import java.nio.file.{Files, Path}
+import java.nio.file.Files
+import fs2.io.file.{Files => Fs2Files, Path}
 
 /** Integration tests for project-aware commands.
   *
@@ -23,40 +24,34 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     result.waitFor() == 0
 
   private def isBinaryAvailable(binary: String): Boolean =
-    java.nio.file.Files.isRegularFile(Path.of(binary)) || isOnPath(binary)
+    java.nio.file.Files.isRegularFile(Path(binary).toNioPath) || isOnPath(binary)
 
   private def withTempDir(test: Path => IO[Unit]): IO[Unit] =
-    IO.blocking(Files.createTempDirectory("cellar-test-")).flatMap { dir =>
-      test(dir).guarantee(IO.blocking {
-        val stream = Files.walk(dir)
-        try stream.sorted(java.util.Comparator.reverseOrder()).forEach(Files.deleteIfExists(_))
-        finally stream.close()
-      })
-    }
+    Fs2Files[IO].tempDirectory.use(test)
 
   // --- ProcessRunner tests ---
 
   test("ProcessRunner: echo captures stdout"):
-    process.ProcessRunner.run(List("echo", "hello")).map { result =>
+    process.ProcessRunner.run("echo", List("hello")).map { result =>
       assertEquals(result.exitCode, 0)
       assertEquals(result.stdout.trim, "hello")
       assert(result.stderr.isEmpty)
     }
 
   test("ProcessRunner: non-zero exit captures stderr"):
-    process.ProcessRunner.run(List("sh", "-c", "echo err >&2; exit 1")).map { result =>
+    process.ProcessRunner.run("sh", List("-c", "echo err >&2; exit 1")).map { result =>
       assertEquals(result.exitCode, 1)
       assert(result.stderr.contains("err"))
     }
 
   test("ProcessRunner: command not found"):
-    process.ProcessRunner.run(List("nonexistent-command-xyz")).attempt.map { result =>
+    process.ProcessRunner.run("nonexistent-command-xyz", Nil).attempt.map { result =>
       assert(result.isLeft)
       assert(result.left.exists(_.getMessage.contains("nonexistent-command-xyz")))
     }
 
   test("ProcessRunner: working directory"):
-    process.ProcessRunner.run(List("pwd"), Some(Path.of("/tmp"))).map { result =>
+    process.ProcessRunner.run("pwd", Nil, Some(Path("/tmp"))).map { result =>
       assertEquals(result.exitCode, 0)
       // /tmp may be a symlink to /private/tmp on macOS
       assert(result.stdout.trim.endsWith("/tmp"))
@@ -66,7 +61,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
 
   test("BuildToolDetector: detects Mill from build.mill"):
     withTempDir { dir =>
-      IO.blocking(Files.createFile(dir.resolve("build.mill"))) >>
+      Fs2Files[IO].createFile(dir.resolve("build.mill")) >>
         build.BuildToolDetector.detectKind(dir).map { kind =>
           assertEquals(kind, build.BuildToolKind.Mill)
         }
@@ -74,7 +69,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
 
   test("BuildToolDetector: detects Mill from build.sc"):
     withTempDir { dir =>
-      IO.blocking(Files.createFile(dir.resolve("build.sc"))) >>
+      Fs2Files[IO].createFile(dir.resolve("build.sc")) >>
         build.BuildToolDetector.detectKind(dir).map { kind =>
           assertEquals(kind, build.BuildToolKind.Mill)
         }
@@ -82,7 +77,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
 
   test("BuildToolDetector: detects sbt from build.sbt"):
     withTempDir { dir =>
-      IO.blocking(Files.createFile(dir.resolve("build.sbt"))) >>
+      Fs2Files[IO].createFile(dir.resolve("build.sbt")) >>
         build.BuildToolDetector.detectKind(dir).map { kind =>
           assertEquals(kind, build.BuildToolKind.Sbt)
         }
@@ -90,7 +85,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
 
   test("BuildToolDetector: detects scala-cli from .scala-build"):
     withTempDir { dir =>
-      IO.blocking(Files.createDirectories(dir.resolve(".scala-build"))) >>
+      Fs2Files[IO].createDirectories(dir.resolve(".scala-build")) >>
         build.BuildToolDetector.detectKind(dir).map { kind =>
           assertEquals(kind, build.BuildToolKind.ScalaCli)
         }
@@ -105,44 +100,43 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
 
   test("BuildToolDetector: Mill takes priority over sbt"):
     withTempDir { dir =>
-      IO.blocking {
-        Files.createFile(dir.resolve("build.mill"))
-        Files.createFile(dir.resolve("build.sbt"))
-      } >>
-        build.BuildToolDetector.detectKind(dir).map { kind =>
-          assertEquals(kind, build.BuildToolKind.Mill)
-        }
+      Fs2Files[IO].createFile(dir.resolve("build.mill")) >>
+      Fs2Files[IO].createFile(dir.resolve("build.sbt")) >>
+      build.BuildToolDetector.detectKind(dir).map { kind =>
+        assertEquals(kind, build.BuildToolKind.Mill)
+      }
     }
 
   test("BuildToolDetector: sbt takes priority over scala-cli"):
     withTempDir { dir =>
-      IO.blocking {
-        Files.createFile(dir.resolve("build.sbt"))
-        Files.createDirectories(dir.resolve(".scala-build"))
-      } >>
-        build.BuildToolDetector.detectKind(dir).map { kind =>
-          assertEquals(kind, build.BuildToolKind.Sbt)
-        }
+      Fs2Files[IO].createFile(dir.resolve("build.sbt")) >>
+      Fs2Files[IO].createDirectories(dir.resolve(".scala-build")) >>
+      build.BuildToolDetector.detectKind(dir).map { kind =>
+        assertEquals(kind, build.BuildToolKind.Sbt)
+      }
     }
 
   // --- ClasspathOutputParser tests ---
 
   test("ClasspathOutputParser: JSON array with refs"):
     val input = """["ref:abc123:/path/to/classes", "/path/to/dep.jar"]"""
-    build.ClasspathOutputParser.parseJsonArray(input, checkExists = false) match
+    build.ClasspathOutputParser.parseJsonArray(input, checkExists = false) map {
       case Right(paths) =>
         assertEquals(paths.map(_.toString), List("/path/to/classes", "/path/to/dep.jar"))
       case Left(err) => fail(err)
+    }
 
   test("ClasspathOutputParser: JSON empty array"):
-    build.ClasspathOutputParser.parseJsonArray("[]", checkExists = false) match
+    build.ClasspathOutputParser.parseJsonArray("[]", checkExists = false) map {
       case Left(err) => assert(err.contains("empty"))
       case Right(_)  => fail("Should fail on empty array")
+    }
 
   test("ClasspathOutputParser: JSON malformed"):
-    build.ClasspathOutputParser.parseJsonArray("not json", checkExists = false) match
+    build.ClasspathOutputParser.parseJsonArray("not json", checkExists = false) map {
       case Left(_)  => () // expected
       case Right(_) => fail("Should fail on malformed input")
+    }
 
   test("ClasspathOutputParser: colon-separated"):
     build.ClasspathOutputParser.parseColonSeparated("/a/b.jar:/c/d.jar\n") match
@@ -167,20 +161,20 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   // --- ScalaCliBuildTool tests ---
 
   test("ScalaCliBuildTool: rejects --module"):
-    build.ScalaCliBuildTool(Path.of(".")).extractClasspath(Some("foo")).attempt.map { result =>
+    build.ScalaCliBuildTool(Path(".")).extractClasspath(Some("foo")).attempt.map { result =>
       assert(result.isLeft)
       assert(result.left.exists(_.getMessage.contains("--module is not supported")))
     }
 
   test("ScalaCliBuildTool: fingerprintFiles returns empty"):
-    build.ScalaCliBuildTool(Path.of(".")).fingerprintFiles().map { files =>
+    build.ScalaCliBuildTool(Path(".")).fingerprintFiles.map { files =>
       assert(files.isEmpty)
     }
 
   // --- MillBuildTool tests ---
 
   test("MillBuildTool: rejects missing --module"):
-    build.MillBuildTool(Path.of(".")).extractClasspath(None).attempt.map { result =>
+    build.MillBuildTool(Path(".")).extractClasspath(None).attempt.map { result =>
       assert(result.isLeft)
       assert(result.left.exists(_.getMessage.contains("--module is required for Mill")))
     }
@@ -188,7 +182,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   // --- SbtBuildTool tests ---
 
   test("SbtBuildTool: rejects missing --module"):
-    build.SbtBuildTool(Path.of(".")).extractClasspath(None).attempt.map { result =>
+    build.SbtBuildTool(Path(".")).extractClasspath(None).attempt.map { result =>
       assert(result.isLeft)
       assert(result.left.exists(_.getMessage.contains("--module is required for sbt")))
     }
@@ -198,7 +192,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
   test("BuildFingerprint: deterministic"):
     withTempDir { dir =>
       val file = dir.resolve("test.txt")
-      IO.blocking(Files.writeString(file, "hello")) >>
+      IO.blocking(Files.writeString(file.toNioPath, "hello")) >>
         (for
           h1 <- build.BuildFingerprint.compute(List(file), "mod")
           h2 <- build.BuildFingerprint.compute(List(file), "mod")
@@ -209,9 +203,9 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val file = dir.resolve("test.txt")
       for
-        _  <- IO.blocking(Files.writeString(file, "hello"))
+        _  <- IO.blocking(Files.writeString(file.toNioPath, "hello"))
         h1 <- build.BuildFingerprint.compute(List(file), "mod")
-        _  <- IO.blocking(Files.writeString(file, "world"))
+        _  <- IO.blocking(Files.writeString(file.toNioPath, "world"))
         h2 <- build.BuildFingerprint.compute(List(file), "mod")
       yield assertNotEquals(h1, h2)
     }
@@ -220,7 +214,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val file = dir.resolve("test.txt")
       for
-        _  <- IO.blocking(Files.writeString(file, "hello"))
+        _  <- IO.blocking(Files.writeString(file.toNioPath, "hello"))
         h1 <- build.BuildFingerprint.compute(List(file), "modA")
         h2 <- build.BuildFingerprint.compute(List(file), "modB")
       yield assertNotEquals(h1, h2)
@@ -231,7 +225,8 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
       val a = dir.resolve("a.txt")
       val b = dir.resolve("b.txt")
       for
-        _  <- IO.blocking { Files.writeString(a, "aaa"); Files.writeString(b, "bbb") }
+        _ <- IO.blocking { Files.writeString(a.toNioPath, "aaa") }
+        _ <- IO.blocking { Files.writeString(b.toNioPath, "bbb") }
         h1 <- build.BuildFingerprint.compute(List(a, b), "mod")
         h2 <- build.BuildFingerprint.compute(List(b, a), "mod")
       yield assertEquals(h1, h2)
@@ -241,7 +236,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val existing = dir.resolve("exists.txt")
       val missing = dir.resolve("nope.txt")
-      IO.blocking(Files.writeString(existing, "data")) >>
+      IO.blocking(Files.writeString(existing.toNioPath, "data")) >>
         build.BuildFingerprint.compute(List(existing, missing), "mod").map { hash =>
           assertEquals(hash.length, 64) // valid SHA-256 hex
         }
@@ -261,7 +256,8 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
       val p1 = dir.resolve("a.jar")
       val p2 = dir.resolve("b.jar")
       for
-        _ <- IO.blocking { Files.createFile(p1); Files.createFile(p2) }
+        _ <- Fs2Files[IO].createFile(p1)
+        _ <- Fs2Files[IO].createFile(p2)
         _ <- cache.put("testhash", List(p1, p2))
         r <- cache.get("testhash")
       yield assertEquals(r, Some(List(p1, p2)))
@@ -279,9 +275,9 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
       val cache = build.ClasspathCache(dir)
       val p1 = dir.resolve("a.jar")
       for
-        _ <- IO.blocking(Files.createFile(p1))
+        _ <- Fs2Files[IO].createFile(p1)
         _ <- cache.put("hash2", List(p1))
-        _ <- IO.blocking(Files.delete(p1))
+        _ <- Fs2Files[IO].delete(p1)
         r <- cache.get("hash2")
       yield assertEquals(r, None)
     }
@@ -293,7 +289,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Main.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Main.scala").toNioPath,
         """package example
           |
           |class MyClass:
@@ -312,7 +308,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Main.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Main.scala").toNioPath,
         """//> using dep org.typelevel::cats-core:2.10.0
           |
           |package example
@@ -332,7 +328,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Main.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Main.scala").toNioPath,
         """package example
           |
           |class MyClass:
@@ -353,7 +349,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Main.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Main.scala").toNioPath,
         """package example
           |
           |class UniqueTestClassName123:
@@ -371,7 +367,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Main.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Main.scala").toNioPath,
         """package example
           |class Foo
           |""".stripMargin
@@ -387,7 +383,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("Bad.scala"),
+      IO.blocking(Files.writeString(dir.resolve("Bad.scala").toNioPath,
         """package example
           |class Bad {
           |  val x: String = 42  // type error
@@ -408,7 +404,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
       val console = CapturingConsole()
       given Console[IO] = console
       IO.blocking {
-        Files.writeString(dir.resolve("build.mill"),
+        Files.writeString(dir.resolve("build.mill").toNioPath,
           """package build
             |import mill._, scalalib._
             |
@@ -417,8 +413,8 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
             |}
             |""".stripMargin
         )
-        Files.createDirectories(dir.resolve("app/src"))
-        Files.writeString(dir.resolve("app/src/Main.scala"),
+        Files.createDirectories(dir.resolve("app/src").toNioPath)
+        Files.writeString(dir.resolve("app/src/Main.scala").toNioPath,
           """package example
             |
             |class MillClass:
@@ -438,7 +434,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("build.mill"), "")) >>
+      IO.blocking(Files.writeString(dir.resolve("build.mill").toNioPath, "")) >>
         handlers.ProjectGetHandler.run("example.Foo", module = None, cwd = Some(dir), millBinary = millBinary).map { code =>
           assertEquals(code, ExitCode.Error)
           assert(console.errBuf.toString.contains("--module is required for Mill"), s"Stderr: ${console.errBuf}")
@@ -453,15 +449,15 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
       val console = CapturingConsole()
       given Console[IO] = console
       IO.blocking {
-        Files.writeString(dir.resolve("build.sbt"),
+        Files.writeString(dir.resolve("build.sbt").toNioPath,
           """lazy val `cellar-test` = (project in file("."))
             |  .settings(scalaVersion := "3.8.1")
             |""".stripMargin
         )
-        Files.createDirectories(dir.resolve("project"))
-        Files.writeString(dir.resolve("project/build.properties"), "sbt.version=1.10.11\n")
-        Files.createDirectories(dir.resolve("src/main/scala/example"))
-        Files.writeString(dir.resolve("src/main/scala/example/Main.scala"),
+        Files.createDirectories(dir.resolve("project").toNioPath)
+        Files.writeString(dir.resolve("project/build.properties").toNioPath, "sbt.version=1.10.11\n")
+        Files.createDirectories(dir.resolve("src/main/scala/example").toNioPath)
+        Files.writeString(dir.resolve("src/main/scala/example/Main.scala").toNioPath,
           """package example
             |
             |class SbtClass:
@@ -480,7 +476,7 @@ class ProjectAwareIntegrationTest extends CatsEffectSuite:
     withTempDir { dir =>
       val console = CapturingConsole()
       given Console[IO] = console
-      IO.blocking(Files.writeString(dir.resolve("build.sbt"), "")) >>
+      IO.blocking(Files.writeString(dir.resolve("build.sbt").toNioPath, "")) >>
         handlers.ProjectGetHandler.run("example.Foo", module = None, cwd = Some(dir)).map { code =>
           assertEquals(code, ExitCode.Error)
           assert(console.errBuf.toString.contains("--module is required for sbt"), s"Stderr: ${console.errBuf}")


### PR DESCRIPTION
To ensure exactly the right operations are executed on blocking threads (which doesn't seem to be the case yet, see https://github.com/VirtusLab/cellar/issues/21) and to reduce the maintenance burden, swap in `fs2-io` for 90% of the I/O-related code. The remaining 10% are deeply involved with virtual file systems and ZIP files, hence I left them as-is for now.

Also use fs2 for spawning external processes and hashing to profit from its safe and easy-to-use APIs.

Tested locally, everything passed just fine. In my brief test, also the hashes were consistent with the previous implementation (which is generally expected as fs2 delegates to `MessageDigest`).

This PR is a proposal, I'm totally fine if it ends up getting discarded. I just fell into the rabbit hole of "let me quickly try to optimise `ProcessRunner`" 🫣. 