### PR TITLE
fix: Add missing zlib input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,7 @@
             nativeBuildInputs = pkgs.lib.optionals pkgs.stdenv.hostPlatform.isLinux [
               pkgs.autoPatchelfHook
               pkgs.glibc
+              pkgs.zlib
             ];
 
             unpackPhase = ''


### PR DESCRIPTION
without this the build command fails with:
```
error: builder for '/nix/store/z8j0zrwy1malq68ji7j25ihrrvn5if3x-cellar-v0.1.0-M6.drv' failed with exit code 1;
       last 25 log lines:
       >           PosixPath('/nix/store/p3l1a5y7nllfyrjn2krlwgcc3z0cd3fq-make-symlinks-relative.sh/lib'),
       >           PosixPath('/nix/store/5yzw0vhkyszf2d179m0qfkgxmp5wjjx4-move-docs.sh/lib'),
       >           PosixPath('/nix/store/fyaryjvghbkpfnsyw97hb3lyb37s1pd6-move-lib64.sh/lib'),
       >           PosixPath('/nix/store/kd4xwxjpjxi71jkm6ka0np72if9rm3y0-move-sbin.sh/lib'),
       >           PosixPath('/nix/store/pag6l61paj1dc9sv15l7bm5c17xn5kyk-move-systemd-user-units.sh/lib'),
       >           PosixPath('/nix/store/cmzya9irvxzlkh7lfy6i82gbp0saxqj3-multiple-outputs.sh/lib'),
       >           PosixPath('/nix/store/x8c40nfigps493a07sdr2pm5s9j1cdc0-patch-shebangs.sh/lib'),
       >           PosixPath('/nix/store/cickvswrvann041nqxb0rxilc46svw1n-prune-libtool-files.sh/lib'),
       >           PosixPath('/nix/store/xyff06pkhki3qy1ls77w10s0v79c9il0-reproducible-builds.sh/lib'),
       >           PosixPath('/nix/store/z7k98578dfzi6l3hsvbivzm7hfqlk0zc-set-source-date-epoch-to-latest.sh/lib'),
       >           PosixPath('/nix/store/pilsssjjdxvdphlg2h19p0bfx5q0jzkn-strip.sh/lib'),
       >           PosixPath('/nix/store/hb2bs5fg5wkm04x565737qd5nh2hy5nk-gcc-wrapper-15.2.0/lib'),
       >           PosixPath('/nix/store/x7ikkplbrv5dlihy1bqq32gp6lilkval-binutils-wrapper-2.44/lib')],
       >  'paths': [PosixPath('/nix/store/sc922qm97nqn859nsn5bwsbw3g1fxczf-cellar-v0.1.0-M6')],
       >  'preserve_origin': False,
       >  'recursive': True,
       >  'runtime_dependencies': [],
       >  'structured_logs': False}
       > setting interpreter of /nix/store/sc922qm97nqn859nsn5bwsbw3g1fxczf-cellar-v0.1.0-M6/bin/cellar
       > searching for dependencies of /nix/store/sc922qm97nqn859nsn5bwsbw3g1fxczf-cellar-v0.1.0-M6/bin/cellar
       >     libz.so.1 -> not found!
       > auto-patchelf: 1 dependencies could not be satisfied
       > error: auto-patchelf could not satisfy dependency libz.so.1 wanted by /nix/store/sc922qm97nqn859nsn5bwsbw3g1fxczf-cellar-v0.1.0-M6/bin/cellar
       > auto-patchelf failed to find all the required dependencies.
       > Add the missing dependencies to --libs or use `--ignore-missing="foo.so.1 bar.so etc.so"`.
       For full logs, run:
         nix log /nix/store/z8j0zrwy1malq68ji7j25ihrrvn5if3x-cellar-v0.1.0-M6.drv
```