### PR TITLE
Show full signatures for companion members in get output

### DIFF
--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -85,7 +85,7 @@ object GetFormatter:
         cls.companionClass.flatMap { companion =>
           val members = companion.declarations
             .filter(m => PublicApiFilter.isPublic(m))
-            .map(_.name.toString)
+            .map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
           if members.isEmpty then None else Some(members.mkString(", "))
         }
       case _ => None

--- a/lib/test/src/cellar/GetFormatterTest.scala
+++ b/lib/test/src/cellar/GetFormatterTest.scala
@@ -159,6 +159,18 @@ class GetFormatterTest extends CatsEffectSuite:
       }
     }
 
+  test("formatSymbol companion members include full signatures"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        val cls    = ctx.findStaticClass("cellar.fixture.scala3.CellarTC")
+        val output = GetFormatter.formatSymbol(cls)
+        assert(output.contains("**Companion members:**"), s"Expected companion section in: $output")
+        assert(output.contains("def apply"), s"Expected 'def apply' signature in companion: $output")
+        assert(output.contains("CellarTC[A]"), s"Expected return type in companion signature: $output")
+      }
+    }
+
   test("formatSymbol members includes all overloaded methods (Scala 2)"):
     withScala2Ctx { ctx =>
       IO.blocking {


### PR DESCRIPTION
## Summary
- Companion members in `cellar get` output now show full type signatures instead of just names
- Previously e.g. `Artifact` companion showed `of, of, of, of`; now shows `def of(x$0: String): Artifact`, etc.

## Test plan
- [x] Added test: `formatSymbol companion members include full signatures`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)