### PR TITLE
Add cellar meta command for POM metadata

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -152,7 +152,9 @@ def fixturePom(desc: String) = PomSettings(
   url = "https://github.com/example/cellar",
   licenses = Seq(License.`Apache-2.0`),
   versionControl = VersionControl.github("example", "cellar"),
-  developers = Seq.empty
+  developers = Seq(
+    Developer("test-dev", "Test Developer", "https://github.com/test-dev")
+  )
 )
 
 object fixtureJava extends JavaModule with PublishModule {

--- a/cli/src/cellar/cli/CellarApp.scala
+++ b/cli/src/cellar/cli/CellarApp.scala
@@ -3,7 +3,7 @@ package cellar.cli
 import cats.effect.{ExitCode, IO}
 import cats.syntax.all.*
 import cellar.*
-import cellar.handlers.{DepsHandler, GetHandler, GetSourceHandler, ListHandler, ProjectGetHandler, ProjectListHandler, ProjectSearchHandler, SearchHandler}
+import cellar.handlers.{DepsHandler, GetHandler, GetSourceHandler, ListHandler, MetaHandler, ProjectGetHandler, ProjectListHandler, ProjectSearchHandler, SearchHandler}
 import com.monovore.decline.*
 import com.monovore.decline.effect.*
 import coursierapi.{MavenRepository, Repository}
@@ -21,7 +21,7 @@ object CellarApp
       getSourceSubcmd orElse
       listSubcmd orElse listExternalSubcmd orElse
       searchSubcmd orElse searchExternalSubcmd orElse
-      depsSubcmd
+      depsSubcmd orElse metaSubcmd
 
   private given Argument[Path] = Argument[java.nio.file.Path].map(Path.fromNioPath)
 
@@ -127,6 +127,16 @@ object CellarApp
         parseAndResolve(rawCoord, extraRepos).flatMap {
           case Left(err)    => IO.blocking(System.err.println(err)).as(ExitCode.Error)
           case Right(coord) => DepsHandler.run(coord, extraRepositories = extraRepos)
+        }
+      }
+    }
+
+  private val metaSubcmd: Opts[IO[ExitCode]] =
+    Opts.subcommand("meta", "Print POM metadata (name, description, license, SCM, developers)") {
+      (coordArg, extraReposOpt).mapN { (rawCoord, extraRepos) =>
+        parseAndResolve(rawCoord, extraRepos).flatMap {
+          case Left(err)    => IO.blocking(System.err.println(err)).as(ExitCode.Error)
+          case Right(coord) => MetaHandler.run(coord, extraRepositories = extraRepos)
         }
       }
     }

--- a/lib/src/cellar/CoursierFetchClient.scala
+++ b/lib/src/cellar/CoursierFetchClient.scala
@@ -34,9 +34,9 @@ object CoursierFetchClient:
       fetch.fetchResult().getArtifacts.asScala
         .map(_.getValue.toPath)
         .find(_.getFileName.toString.endsWith(".jar"))
-        .map { jarNio =>
-          val pomName = jarNio.getFileName.toString.stripSuffix(".jar") + ".pom"
-          Path.fromNioPath(jarNio.getParent.resolve(pomName))
+        .flatMap { jarNio =>
+          val pomNio = jarNio.getParent.resolve(jarNio.getFileName.toString.stripSuffix(".jar") + ".pom")
+          Option.when(java.nio.file.Files.exists(pomNio))(Path.fromNioPath(pomNio))
         }
     }.handleErrorWith {
       case e: coursierapi.error.CoursierError =>

--- a/lib/src/cellar/CoursierFetchClient.scala
+++ b/lib/src/cellar/CoursierFetchClient.scala
@@ -22,6 +22,30 @@ object CoursierFetchClient:
       fetch.fetch().asScala.headOption.map(file => Path.fromNioPath(file.toPath))
     }.handleError(_ => None)
 
+  def fetchPom(
+      coord: MavenCoordinate,
+      extraRepositories: Seq[Repository] = Seq.empty
+  ): IO[Option[Path]] =
+    IO.blocking {
+      val dep   = coord.toCoursierDependency.withTransitive(false)
+      val fetch = Fetch.create().addDependencies(dep).withCache(Cache.create())
+      if extraRepositories.nonEmpty then fetch.addRepositories(extraRepositories*)
+      // Coursier always downloads the POM during resolution; derive its path from the JAR
+      fetch.fetchResult().getArtifacts.asScala
+        .map(_.getValue.toPath)
+        .find(_.getFileName.toString.endsWith(".jar"))
+        .map { jarNio =>
+          val pomName = jarNio.getFileName.toString.stripSuffix(".jar") + ".pom"
+          Path.fromNioPath(jarNio.getParent.resolve(pomName))
+        }
+    }.handleErrorWith {
+      case e: coursierapi.error.CoursierError =>
+        CoordinateCompleter.suggest(coord, extraRepositories).flatMap { suggestions =>
+          IO.raiseError(CellarError.CoordinateNotFound(coord, e, suggestions))
+        }
+      case e => IO.raiseError(e)
+    }
+
   def fetchClasspath(
       coord: MavenCoordinate,
       extraRepositories: Seq[Repository] = Seq.empty

--- a/lib/src/cellar/CoursierFetchClient.scala
+++ b/lib/src/cellar/CoursierFetchClient.scala
@@ -30,10 +30,8 @@ object CoursierFetchClient:
       val dep   = coord.toCoursierDependency.withTransitive(false)
       val fetch = Fetch.create().addDependencies(dep).withCache(Cache.create())
       if extraRepositories.nonEmpty then fetch.addRepositories(extraRepositories*)
-      // Coursier always downloads the POM during resolution; derive its path from the JAR
-      fetch.fetchResult().getArtifacts.asScala
-        .map(_.getValue.toPath)
-        .find(_.getFileName.toString.endsWith(".jar"))
+      // Coursier always downloads the POM alongside the JAR in the cache; derive its path
+      fetch.fetch().asScala.headOption.map(_.toPath)
         .flatMap { jarNio =>
           val pomNio = jarNio.getParent.resolve(jarNio.getFileName.toString.stripSuffix(".jar") + ".pom")
           Option.when(java.nio.file.Files.exists(pomNio))(Path.fromNioPath(pomNio))

--- a/lib/src/cellar/MetaFormatter.scala
+++ b/lib/src/cellar/MetaFormatter.scala
@@ -1,0 +1,25 @@
+package cellar
+
+object MetaFormatter:
+  def format(meta: PomMeta): String =
+    val lines = List.newBuilder[String]
+
+    meta.name.foreach(v => lines += s"Name:        $v")
+    meta.description.foreach(v => lines += s"Description: $v")
+    meta.url.foreach(v => lines += s"URL:         $v")
+
+    meta.licenses.foreach { (name, url) =>
+      val rendered = url.fold(name)(u => s"$name ($u)")
+      lines += s"License:     $rendered"
+    }
+
+    meta.scm.foreach(v => lines += s"SCM:         $v")
+
+    if meta.developers.nonEmpty then
+      lines += "Developers:"
+      meta.developers.foreach { (name, email) =>
+        val rendered = email.fold(name)(e => s"$name <$e>")
+        lines += s"  - $rendered"
+      }
+
+    lines.result().mkString("\n")

--- a/lib/src/cellar/PomParser.scala
+++ b/lib/src/cellar/PomParser.scala
@@ -2,6 +2,7 @@ package cellar
 
 import org.w3c.dom.Element
 
+import javax.xml.XMLConstants
 import javax.xml.parsers.DocumentBuilderFactory
 
 final case class PomMeta(
@@ -16,7 +17,13 @@ final case class PomMeta(
 
 object PomParser:
   def parse(path: fs2.io.file.Path, coord: MavenCoordinate): PomMeta =
-    val doc  = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(path.toNioPath.toFile)
+    val factory = DocumentBuilderFactory.newInstance()
+    factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+    factory.setFeature("http://xml.org/sax/features/external-general-entities", false)
+    factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "")
+    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "")
+    val doc  = factory.newDocumentBuilder().parse(path.toNioPath.toFile)
     val root = doc.getDocumentElement
 
     def text(tag: String): Option[String] =
@@ -40,12 +47,14 @@ object PomParser:
       val nodes = el.getElementsByTagName(tag)
       Option.when(nodes.getLength > 0)(nodes.item(0).getTextContent.trim).filter(_.nonEmpty)
 
-    val licenses = children("licenses", "license").map { el =>
-      (elemText(el, "name").getOrElse(""), elemText(el, "url"))
+    val licenses = children("licenses", "license").flatMap { el =>
+      elemText(el, "name").map(name => (name, elemText(el, "url")))
     }
 
-    val developers = children("developers", "developer").map { el =>
-      (elemText(el, "name").getOrElse(""), elemText(el, "email"))
+    val developers = children("developers", "developer").flatMap { el =>
+      val name  = elemText(el, "name")
+      val email = elemText(el, "email")
+      (name orElse email).map(display => (display, if name.isDefined then email else None))
     }
 
     val scm =

--- a/lib/src/cellar/PomParser.scala
+++ b/lib/src/cellar/PomParser.scala
@@ -1,0 +1,64 @@
+package cellar
+
+import org.w3c.dom.Element
+
+import javax.xml.parsers.DocumentBuilderFactory
+
+final case class PomMeta(
+    coordinate: MavenCoordinate,
+    name: Option[String],
+    description: Option[String],
+    url: Option[String],
+    licenses: Seq[(String, Option[String])],
+    scm: Option[String],
+    developers: Seq[(String, Option[String])],
+)
+
+object PomParser:
+  def parse(path: fs2.io.file.Path, coord: MavenCoordinate): PomMeta =
+    val doc  = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(path.toNioPath.toFile)
+    val root = doc.getDocumentElement
+
+    def text(tag: String): Option[String] =
+      val kids = root.getChildNodes
+      (0 until kids.getLength)
+        .map(kids.item)
+        .collectFirst { case e: Element if e.getTagName == tag => e.getTextContent.trim }
+        .filter(_.nonEmpty)
+
+    def children(parentTag: String, childTag: String): Seq[Element] =
+      val parents = root.getElementsByTagName(parentTag)
+      if parents.getLength == 0 then Seq.empty
+      else
+        val parent = parents.item(0)
+        val kids   = parent.getChildNodes
+        (0 until kids.getLength)
+          .map(kids.item)
+          .collect { case e: Element if e.getTagName == childTag => e }
+
+    def elemText(el: Element, tag: String): Option[String] =
+      val nodes = el.getElementsByTagName(tag)
+      Option.when(nodes.getLength > 0)(nodes.item(0).getTextContent.trim).filter(_.nonEmpty)
+
+    val licenses = children("licenses", "license").map { el =>
+      (elemText(el, "name").getOrElse(""), elemText(el, "url"))
+    }
+
+    val developers = children("developers", "developer").map { el =>
+      (elemText(el, "name").getOrElse(""), elemText(el, "email"))
+    }
+
+    val scm =
+      val scms = root.getElementsByTagName("scm")
+      if scms.getLength == 0 then None
+      else elemText(scms.item(0).asInstanceOf[Element], "url")
+
+    PomMeta(
+      coordinate = coord,
+      name = text("name"),
+      description = text("description"),
+      url = text("url"),
+      licenses = licenses,
+      scm = scm,
+      developers = developers,
+    )

--- a/lib/src/cellar/PomParser.scala
+++ b/lib/src/cellar/PomParser.scala
@@ -26,10 +26,11 @@ object PomParser:
     val doc  = factory.newDocumentBuilder().parse(path.toNioPath.toFile)
     val root = doc.getDocumentElement
 
+    def nodeSeq(nl: org.w3c.dom.NodeList): Seq[org.w3c.dom.Node] =
+      (0 until nl.getLength).map(nl.item)
+
     def text(tag: String): Option[String] =
-      val kids = root.getChildNodes
-      (0 until kids.getLength)
-        .map(kids.item)
+      nodeSeq(root.getChildNodes)
         .collectFirst { case e: Element if e.getTagName == tag => e.getTextContent.trim }
         .filter(_.nonEmpty)
 
@@ -37,10 +38,7 @@ object PomParser:
       val parents = root.getElementsByTagName(parentTag)
       if parents.getLength == 0 then Seq.empty
       else
-        val parent = parents.item(0)
-        val kids   = parent.getChildNodes
-        (0 until kids.getLength)
-          .map(kids.item)
+        nodeSeq(parents.item(0).getChildNodes)
           .collect { case e: Element if e.getTagName == childTag => e }
 
     def elemText(el: Element, tag: String): Option[String] =

--- a/lib/src/cellar/handlers/MetaHandler.scala
+++ b/lib/src/cellar/handlers/MetaHandler.scala
@@ -1,0 +1,25 @@
+package cellar.handlers
+
+import cats.effect.{ExitCode, IO}
+import cats.effect.std.Console
+import cellar.*
+import coursierapi.Repository
+
+object MetaHandler:
+  def run(
+      coord: MavenCoordinate,
+      extraRepositories: Seq[Repository] = Seq.empty
+  )(using Console[IO]): IO[ExitCode] =
+    val program =
+      for
+        pomPath  <- CoursierFetchClient.fetchPom(coord, extraRepositories)
+        path     <- IO.fromOption(pomPath)(CellarError.CoordinateNotFound(coord, new RuntimeException("POM not found")))
+        meta     <- IO.blocking(PomParser.parse(path, coord))
+        formatted = MetaFormatter.format(meta)
+        _        <- Console[IO].println(formatted)
+      yield ExitCode.Success
+
+    program.handleErrorWith {
+      case e: CellarError => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
+      case e: Throwable   => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
+    }

--- a/lib/src/cellar/handlers/MetaHandler.scala
+++ b/lib/src/cellar/handlers/MetaHandler.scala
@@ -19,7 +19,6 @@ object MetaHandler:
         _        <- Console[IO].println(formatted)
       yield ExitCode.Success
 
-    program.handleErrorWith {
-      case e: CellarError => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
-      case e: Throwable   => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
+    program.handleErrorWith { e =>
+      Console[IO].errorln(e.getMessage).as(ExitCode.Error)
     }

--- a/lib/test/src/cellar/MetaHandlerTest.scala
+++ b/lib/test/src/cellar/MetaHandlerTest.scala
@@ -1,0 +1,55 @@
+package cellar
+
+import cats.effect.{ExitCode, IO}
+import cats.effect.std.Console
+import cellar.handlers.MetaHandler
+import munit.CatsEffectSuite
+
+class MetaHandlerTest extends CatsEffectSuite:
+
+  private def run(coord: MavenCoordinate): IO[(ExitCode, String)] =
+    TestFixtures.assumeFixturesAvailable()
+    val console = CapturingConsole()
+    given Console[IO] = console
+    MetaHandler.run(coord, extraRepositories = Seq(TestFixtures.localM2Repo))
+      .map(code => (code, console.outBuf.toString))
+
+  test("meta: scala3 fixture exits 0"):
+    run(TestFixtures.scala3Coord).map { (code, _) =>
+      assertEquals(code, ExitCode.Success)
+    }
+
+  test("meta: scala3 fixture shows description"):
+    run(TestFixtures.scala3Coord).map { (_, out) =>
+      assert(out.contains("Cellar Scala 3 test fixture"), s"Output: $out")
+    }
+
+  test("meta: scala3 fixture shows project URL"):
+    run(TestFixtures.scala3Coord).map { (_, out) =>
+      assert(out.contains("https://github.com/example/cellar"), s"Output: $out")
+    }
+
+  test("meta: scala3 fixture shows Apache-2.0 license"):
+    run(TestFixtures.scala3Coord).map { (_, out) =>
+      assert(out.contains("Apache-2.0"), s"Output: $out")
+    }
+
+  test("meta: scala3 fixture shows SCM URL"):
+    run(TestFixtures.scala3Coord).map { (_, out) =>
+      assert(out.contains("github.com/example/cellar"), s"Output: $out")
+    }
+
+  test("meta: scala3 fixture shows developer"):
+    run(TestFixtures.scala3Coord).map { (_, out) =>
+      assert(out.contains("Test Developer"), s"Output: $out")
+    }
+
+  test("meta: java fixture shows description"):
+    run(TestFixtures.javaCoord).map { (_, out) =>
+      assert(out.contains("Cellar Java test fixture"), s"Output: $out")
+    }
+
+  test("meta: scala2 fixture shows description"):
+    run(TestFixtures.scala2Coord).map { (_, out) =>
+      assert(out.contains("Cellar Scala 2.13 test fixture"), s"Output: $out")
+    }


### PR DESCRIPTION
## Summary

- Adds `cellar meta <coordinate>` command that fetches and displays POM metadata for any Maven artifact
- Displays: name, description, URL, license(s), SCM URL, and developers
- Uses Coursier to resolve the artifact (derives POM path from the downloaded JAR), then parses with the JRE's built-in DOM parser
- No project-aware variant — POM metadata is inherently coordinate-based
- Supports `--repository` / `-r` flags like all other external commands
- Closes #30

## Test plan

- [ ] Added `Developer` to `fixturePom` in `build.mill` so all three test fixtures have meaningful metadata
- [ ] `MetaHandlerTest` covers: exit code, description, URL, license, SCM, developer (scala3 fixture), and distinct descriptions for java/scala2 fixtures
- [ ] Manual smoke test: `cellar meta org.typelevel:cats-core_3:2.12.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)