### PR TITLE
Rank exact-name matches first in search results

### DIFF
--- a/lib/src/cellar/handlers/SearchHandler.scala
+++ b/lib/src/cellar/handlers/SearchHandler.scala
@@ -38,9 +38,10 @@ object SearchHandler:
     val matchingStream = AllSymbolsStream
       .stream(classpath, jreClasspath)
       .filter(sym => sym.name.toString.toLowerCase.contains(lowerQuery))
-    // Collect all matches, sort shortest name first (closest match), then apply limit
+    // Rank exact-name matches first, then prefix matches, then by length — so
+    // `Monad` beats `Bimonad`/`MonadError` regardless of declaration order.
     matchingStream.compile.toList.flatMap { allMatches =>
-      val sorted  = allMatches.sortBy(_.name.toString.length)
+      val sorted  = allMatches.sortBy(sym => rankKey(lowerQuery, sym.name.toString))
       val limited = sorted.take(limit)
       val note    = if sorted.length > limit then
         Console[IO].errorln(s"Note: results truncated at $limit. Use --limit to increase.")
@@ -53,3 +54,13 @@ object SearchHandler:
         }.flatMap(Console[IO].println)
       } >> note.as(ExitCode.Success)
     }
+
+  /**
+   * Sort key for search results. `lowerQuery` must already be lower-cased.
+   * Order: exact name match → prefix match → shorter name → alphabetical.
+   */
+  private[cellar] def rankKey(lowerQuery: String, name: String): (Int, Int, Int, String) =
+    val lowerName = name.toLowerCase
+    val exact     = if lowerName == lowerQuery then 0 else 1
+    val prefix    = if lowerName.startsWith(lowerQuery) then 0 else 1
+    (exact, prefix, name.length, name)

--- a/lib/test/src/cellar/SearchHandlerTest.scala
+++ b/lib/test/src/cellar/SearchHandlerTest.scala
@@ -1,0 +1,40 @@
+package cellar
+
+import cellar.handlers.SearchHandler
+import munit.FunSuite
+
+class SearchHandlerTest extends FunSuite:
+
+  private def sort(query: String, names: List[String]): List[String] =
+    val lower = query.toLowerCase
+    names.sortBy(SearchHandler.rankKey(lower, _))
+
+  test("rankKey: exact match sorts before substring matches"):
+    val sorted = sort("Monad", List("Bimonad", "Comonad", "Monad", "MonadError"))
+    assertEquals(sorted.head, "Monad")
+
+  test("rankKey: exact match wins against longer prefix matches"):
+    val sorted = sort("Map", List("MapLike", "Map", "MapOps"))
+    assertEquals(sorted.head, "Map")
+
+  test("rankKey: case-insensitive exact match"):
+    val sorted = sort("monad", List("Bimonad", "Monad", "Comonad"))
+    assertEquals(sorted.head, "Monad")
+
+  test("rankKey: prefix matches outrank same-length non-prefix matches"):
+    // Both "PreXYZ" and "XYZPre" contain "Pre" and are length 6;
+    // the prefix match should win.
+    val sorted = sort("Pre", List("XYZPre", "PreXYZ"))
+    assertEquals(sorted, List("PreXYZ", "XYZPre"))
+
+  test("rankKey: within equal rank, shorter names come first"):
+    val sorted = sort("Foo", List("FooBarBaz", "FooBar"))
+    assertEquals(sorted, List("FooBar", "FooBarBaz"))
+
+  test("rankKey: within equal length, alphabetical"):
+    val sorted = sort("Foo", List("FooC", "FooA", "FooB"))
+    assertEquals(sorted, List("FooA", "FooB", "FooC"))
+
+  test("rankKey: companion module ($-suffixed) sorts right after exact match"):
+    val sorted = sort("Monad", List("MonadError", "Monad$", "Monad", "Bimonad"))
+    assertEquals(sorted.take(2), List("Monad", "Monad$"))


### PR DESCRIPTION
Replace length-only sort with a tuple key (exact, prefix, length, name) so short substring siblings like `Bimonad`/`MonadError` no longer crowd out the exact `Monad` hit the user actually typed.

Fixes #42