### PR TITLE
Resolve companion members via <Class>.<member>

### DIFF
--- a/fixtureScala3/src/cellar/fixture/scala3/CellarNested.scala
+++ b/fixtureScala3/src/cellar/fixture/scala3/CellarNested.scala
@@ -13,3 +13,14 @@ trait CellarMid extends CellarOuter:
 
 trait CellarLeaf extends CellarMid:
   def leafMethod: Boolean
+
+/** Fixture for testing resolution of members declared on the companion. */
+trait CellarWithCompanion:
+  def instanceMethod: Int
+
+object CellarWithCompanion:
+  def apply(): CellarWithCompanion = new CellarWithCompanion:
+    def instanceMethod: Int = 0
+
+  trait CompanionNested:
+    def nestedMethod: String

--- a/lib/src/cellar/SymbolResolver.scala
+++ b/lib/src/cellar/SymbolResolver.scala
@@ -77,14 +77,29 @@ object SymbolResolver:
         case None =>
           return Some(LookupResult.PartialMatch(currentResolved, seg))
 
-    // Final segment: walk linearization for term overloads + type members
+    // Final segment: walk linearization for term overloads + type members.
+    // If the instance side has nothing, fall through to the companion module
+    // so `Foo.apply` resolves to `object Foo`'s `apply`.
     val finalSeg = segments(segments.length - 1)
-    val tName = termName(finalSeg)
-    val tyName = typeName(finalSeg)
+    val tName    = termName(finalSeg)
+    val tyName   = typeName(finalSeg)
+    val direct   = collectFinalMembers(current, tName, tyName)
+    val all =
+      if direct.nonEmpty then direct
+      else current.companionClass.toList.flatMap(collectFinalMembers(_, tName, tyName))
+
+    if all.isEmpty then Some(LookupResult.PartialMatch(currentResolved, finalSeg))
+    else Some(LookupResult.Found(all))
+
+  private def collectFinalMembers(
+      cls: ClassSymbol,
+      tName: tastyquery.Names.UnsignedTermName,
+      tyName: tastyquery.Names.TypeName
+  )(using ctx: Context): List[Symbol] =
     val linearization =
-      try current.linearization
-      catch case _: Exception => List(current)
-    val seen = scala.collection.mutable.Set.empty[Symbol]
+      try cls.linearization
+      catch case _: Exception => List(cls)
+    val seen    = scala.collection.mutable.Set.empty[Symbol]
     val results = List.newBuilder[Symbol]
     for klass <- linearization do
       for sym <- klass.getAllOverloadedDecls(tName) if !seen.contains(sym) do
@@ -93,16 +108,20 @@ object SymbolResolver:
       for sym <- klass.getDecl(tyName) if !seen.contains(sym) do
         seen += sym
         results += sym
-    val all = results.result().filter(PublicApiFilter.isPublic)
-
-    if all.isEmpty then Some(LookupResult.PartialMatch(currentResolved, finalSeg))
-    else Some(LookupResult.Found(all))
+    results.result().filter(PublicApiFilter.isPublic)
 
   /**
    * Find a nested class member by name, walking the linearization.
    * Tries type members first (traits, classes), then term members (objects).
+   * Falls through to the companion class so `Foo.Bar` resolves when `Bar` is
+   * declared inside `object Foo` rather than on the `Foo` trait/class itself.
    */
   private[cellar] def findClassMember(owner: ClassSymbol, name: String)(using ctx: Context): Option[ClassSymbol] =
+    directClassMember(owner, name).orElse {
+      owner.companionClass.flatMap(directClassMember(_, name))
+    }
+
+  private def directClassMember(owner: ClassSymbol, name: String)(using ctx: Context): Option[ClassSymbol] =
     val byType = owner.getMember(typeName(name)).collect { case cs: ClassSymbol => cs }
     byType.orElse {
       owner.getMember(termName(name)).flatMap(_.moduleClass)

--- a/lib/test/src/cellar/SymbolResolverTest.scala
+++ b/lib/test/src/cellar/SymbolResolverTest.scala
@@ -133,3 +133,60 @@ class SymbolResolverTest extends CatsEffectSuite:
         case other => fail(s"Expected Found for trailing-\\$$ FQN, got $other")
       }
     }
+
+  test("resolve companion term member via <Trait>.<member>"):
+    withCtx { ctx =>
+      given Context = ctx
+      // `apply` lives on `object CellarWithCompanion`, not on the trait.
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarWithCompanion.apply").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.nonEmpty)
+          assert(syms.exists(_.name.toString == "apply"))
+        case other => fail(s"Expected Found for companion apply, got $other")
+      }
+    }
+
+  test("resolve companion-nested type via <Trait>.<NestedType>"):
+    withCtx { ctx =>
+      given Context = ctx
+      // `CompanionNested` is a trait declared inside `object CellarWithCompanion`.
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarWithCompanion.CompanionNested").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.nonEmpty)
+        case other => fail(s"Expected Found for companion-nested type, got $other")
+      }
+    }
+
+  test("resolve member of companion-nested type via <Trait>.<NestedType>.<member>"):
+    withCtx { ctx =>
+      given Context = ctx
+      // Exercises the intermediate companion fallback in findClassMember.
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarWithCompanion.CompanionNested.nestedMethod").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.nonEmpty)
+          assert(syms.exists(_.name.toString == "nestedMethod"))
+        case other => fail(s"Expected Found for nested member via companion, got $other")
+      }
+    }
+
+  test("instance-side resolution still wins over companion"):
+    withCtx { ctx =>
+      given Context = ctx
+      // `instanceMethod` is on the trait, not the companion — must still resolve to the trait's decl.
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarWithCompanion.instanceMethod").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.exists(_.name.toString == "instanceMethod"))
+        case other => fail(s"Expected Found for instance member, got $other")
+      }
+    }
+
+  test("resolve non-existent member on class with companion still returns PartialMatch"):
+    withCtx { ctx =>
+      given Context = ctx
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarWithCompanion.nonExistentXYZ").map {
+        case LookupResult.PartialMatch(resolved, missing) =>
+          assert(resolved.contains("CellarWithCompanion"), s"Expected resolved to contain CellarWithCompanion, got $resolved")
+          assertEquals(missing, "nonExistentXYZ")
+        case other => fail(s"Expected PartialMatch, got $other")
+      }
+    }


### PR DESCRIPTION
SymbolResolver now falls through to the companion class in two places: the final-segment member lookup (so `cats.Monad.apply` resolves to the companion's `apply`) and the intermediate nested walk in findClassMember (so `Foo.Bar.baz` works when `Bar` lives in `object Foo`).

Instance-side resolution still wins when a member exists on both sides, and genuinely missing members continue to produce PartialMatch.

Fixes #43 