### PR TITLE
Include companion object in get-source output

### DIFF
--- a/lib/src/cellar/SymbolResolver.scala
+++ b/lib/src/cellar/SymbolResolver.scala
@@ -22,11 +22,17 @@ object SymbolResolver:
 
   /** Try to resolve as a top-level class, module, term, type, or package. */
   private def tryTopLevel(fqn: String)(using ctx: Context): Option[LookupResult] =
-    tryOrNone(ctx.findStaticClass(fqn)).map(s => LookupResult.Found(List(s)))
-      .orElse(tryOrNone(ctx.findStaticModuleClass(fqn)).map(s => LookupResult.Found(List(s))))
-      .orElse(tryOrNone(ctx.findStaticTerm(fqn)).map(s => LookupResult.Found(List(s))))
-      .orElse(tryOrNone(ctx.findStaticType(fqn)).map(s => LookupResult.Found(List(s))))
-      .orElse(tryOrNone(ctx.findPackage(fqn)).map(_ => LookupResult.IsPackage))
+    // A trailing `$` is the JVM-level name of a companion object — treat it as
+    // an explicit request for the module class, not the class of the same name.
+    if fqn.endsWith("$") then
+      val stripped = fqn.stripSuffix("$")
+      tryOrNone(ctx.findStaticModuleClass(stripped)).map(s => LookupResult.Found(List(s)))
+    else
+      tryOrNone(ctx.findStaticClass(fqn)).map(s => LookupResult.Found(List(s)))
+        .orElse(tryOrNone(ctx.findStaticModuleClass(fqn)).map(s => LookupResult.Found(List(s))))
+        .orElse(tryOrNone(ctx.findStaticTerm(fqn)).map(s => LookupResult.Found(List(s))))
+        .orElse(tryOrNone(ctx.findStaticType(fqn)).map(s => LookupResult.Found(List(s))))
+        .orElse(tryOrNone(ctx.findPackage(fqn)).map(_ => LookupResult.IsPackage))
 
   /**
    * Multi-segment nested member walk.

--- a/lib/src/cellar/handlers/GetSourceHandler.scala
+++ b/lib/src/cellar/handlers/GetSourceHandler.scala
@@ -7,7 +7,7 @@ import coursierapi.Repository
 import fs2.io.file.Path
 import tastyquery.Contexts.Context
 import tastyquery.SourceLanguage
-import tastyquery.Symbols.TermOrTypeSymbol
+import tastyquery.Symbols.{ClassSymbol, Symbol, TermOrTypeSymbol}
 import tastyquery.Trees.Tree
 
 object GetSourceHandler:
@@ -30,7 +30,7 @@ object GetSourceHandler:
                 IO.raiseError(CellarError.SymbolNotFound(fqn, coord, nearMatches))
               }
             case LookupResult.Found(symbols) =>
-              IO.blocking(sourceRef(symbols.head)).flatMap {
+              IO.blocking(combinedSourceRef(symbols.head)(using ctx)).flatMap {
                 case None =>
                   Console[IO].errorln(
                     s"No source position for '$fqn'. Only Scala 3 (TASTy) and Java symbols are supported."
@@ -55,7 +55,23 @@ object GetSourceHandler:
       case e: Throwable   => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
     }
 
-  private def sourceRef(sym: tastyquery.Symbols.Symbol): Option[(String, Int, Int, String)] =
+  /**
+   * Resolve the source range for `sym`. When `sym` is a ClassSymbol whose
+   * companion lives in the same source file, widen the range to cover both —
+   * so `get-source cats.Monad` returns the trait *and* `object Monad` in one
+   * slice, which is where `apply`, type-class summoners, etc. actually live.
+   */
+  private def combinedSourceRef(sym: Symbol)(using Context): Option[(String, Int, Int, String)] =
+    val primary = sourceRef(sym)
+    val companion = sym match
+      case cls: ClassSymbol => cls.companionClass.flatMap(sourceRef)
+      case _                => None
+    (primary, companion) match
+      case (Some(p), Some(c)) if p._1 == c._1 && p._4 == c._4 =>
+        Some((p._1, math.min(p._2, c._2), math.max(p._3, c._3), p._4))
+      case _ => primary
+
+  private def sourceRef(sym: Symbol): Option[(String, Int, Int, String)] =
     sym.tree.flatMap { t =>
       val pos = t.asInstanceOf[Tree].pos
       if pos.isUnknown || pos.isSynthetic || pos.sourceFile == tastyquery.SourceFile.NoSource then None

--- a/lib/test/src/cellar/IntegrationTest.scala
+++ b/lib/test/src/cellar/IntegrationTest.scala
@@ -233,6 +233,39 @@ class IntegrationTest extends CatsEffectSuite:
         assert(console.outBuf.toString.contains("```java"), s"Output: ${console.outBuf}")
       }
 
+  test("get-source: trait with same-file companion returns both"):
+    TestFixtures.assumeFixturesAvailable()
+    val console = CapturingConsole()
+    given Console[IO] = console
+    handlers.GetSourceHandler
+      .run(
+        TestFixtures.scala3Coord,
+        "cellar.fixture.scala3.CellarTC",
+        extraRepositories = Seq(TestFixtures.localM2Repo)
+      )
+      .map { code =>
+        assertEquals(code, ExitCode.Success)
+        val out = console.outBuf.toString
+        assert(out.contains("trait CellarTC"), s"Expected 'trait CellarTC' in: $out")
+        assert(out.contains("object CellarTC"), s"Expected 'object CellarTC' in: $out")
+      }
+
+  test("get-source: trailing-$ FQN returns companion source"):
+    TestFixtures.assumeFixturesAvailable()
+    val console = CapturingConsole()
+    given Console[IO] = console
+    handlers.GetSourceHandler
+      .run(
+        TestFixtures.scala3Coord,
+        "cellar.fixture.scala3.CellarTC$",
+        extraRepositories = Seq(TestFixtures.localM2Repo)
+      )
+      .map { code =>
+        assertEquals(code, ExitCode.Success)
+        val out = console.outBuf.toString
+        assert(out.contains("object CellarTC"), s"Expected 'object CellarTC' in: $out")
+      }
+
   // ─── list subcommand ─────────────────────────────────────────────────────
 
   test("list: package scala3 fixture lists top-level types"):

--- a/lib/test/src/cellar/SymbolResolverTest.scala
+++ b/lib/test/src/cellar/SymbolResolverTest.scala
@@ -117,3 +117,19 @@ class SymbolResolverTest extends CatsEffectSuite:
         case other => fail(s"Expected Found for inherited nested type, got $other")
       }
     }
+
+  test("resolve trailing-$ FQN returns the companion module class"):
+    withCtx { ctx =>
+      given Context = ctx
+      // `cellar.fixture.scala3.CellarTC$` should resolve to `object CellarTC`,
+      // not the trait of the same name.
+      SymbolResolver.resolve("cellar.fixture.scala3.CellarTC$").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.nonEmpty)
+          syms.head match
+            case cls: tastyquery.Symbols.ClassSymbol =>
+              assert(cls.isModuleClass, s"Expected module class, got $cls")
+            case other => fail(s"Expected ClassSymbol, got $other")
+        case other => fail(s"Expected Found for trailing-\\$$ FQN, got $other")
+      }
+    }


### PR DESCRIPTION
GetSourceHandler now widens the fetched line range to cover both a class and its companion when they live in the same source file, so that `get-source cats.Monad` returns the trait *and* `object Monad` — where `apply`, `Ops`, `ToMonadOps` and other summoner machinery actually live.

Also teach SymbolResolver.tryTopLevel to strip a trailing `$` and route it to findStaticModuleClass, so `cats.Monad$` explicitly resolves to the companion module class instead of falling through to NotFound.

Fixes #41 