### PR TITLE
Issues/44

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ cellar get-external org.typelevel:cats-core_3:latest cats.Monad
 | `--java-home <path>` | all | Use a specific JDK for JRE classpath |
 | `-r`, `--repository <url>` | external commands | Extra Maven repository URL (repeatable) |
 | `-l`, `--limit <N>` | `list`, `list-external`, `search`, `search-external` | Max results (default: 50) |
+| `-l`, `--limit <N>` | `get`, `get-external` | Max members to display (no default) |
+| `--hide-inherited` | `get`, `get-external` | Show only members declared on the type itself |
+| `--group-inherited` | `get`, `get-external` | Group members by declaring type with section headers |
 
 ## Configuration
 

--- a/cli/src/cellar/cli/CellarApp.scala
+++ b/cli/src/cellar/cli/CellarApp.scala
@@ -52,11 +52,22 @@ object CellarApp
       .option[Int]("limit", "Maximum number of results to return", short = "l", metavar = "N")
       .withDefault(50)
 
+  private val memberLimitOpt: Opts[Option[Int]] =
+    Opts
+      .option[Int]("limit", "Maximum number of members to display", short = "l", metavar = "N")
+      .orNone
+
   private val moduleOpt: Opts[Option[String]] =
     Opts.option[String]("module", "Build module name (required for Mill/sbt)", short = "m", metavar = "name").orNone
 
   private val noCacheOpt: Opts[Boolean] =
     Opts.flag("no-cache", "Skip classpath cache (re-extract from build tool)").orFalse
+
+  private val hideInheritedOpt: Opts[Boolean] =
+    Opts.flag("hide-inherited", "Show only members declared on the type itself").orFalse
+
+  private val groupInheritedOpt: Opts[Boolean] =
+    Opts.flag("group-inherited", "Group members by declaring type with section headers").orFalse
 
   private def parseAndResolve(raw: String, extraRepos: List[Repository]): IO[Either[String, MavenCoordinate]] =
     MavenCoordinate.parse(raw) match
@@ -65,8 +76,9 @@ object CellarApp
 
   private val getSubcmd: Opts[IO[ExitCode]] =
     Opts.subcommand("get", "Fetch symbol info from the current project") {
-      (symbolArg, moduleOpt, javaHomeOpt, noCacheOpt).mapN { (fqn, module, javaHome, noCache) =>
-        ProjectGetHandler.run(fqn, module, javaHome, noCache)
+      (symbolArg, moduleOpt, memberLimitOpt, hideInheritedOpt, groupInheritedOpt, javaHomeOpt, noCacheOpt).mapN {
+        (fqn, module, limit, hideInherited, groupInherited, javaHome, noCache) =>
+          ProjectGetHandler.run(fqn, module, javaHome, noCache, limit, hideInherited, groupInherited)
       }
     }
 
@@ -87,11 +99,12 @@ object CellarApp
 
   private val getExternalSubcmd: Opts[IO[ExitCode]] =
     Opts.subcommand("get-external", "Fetch symbol info from a Maven coordinate") {
-      (coordArg, symbolArg, javaHomeOpt, extraReposOpt).mapN { (rawCoord, fqn, javaHome, extraRepos) =>
-        parseAndResolve(rawCoord, extraRepos).flatMap {
-          case Left(err)    => IO.blocking(System.err.println(err)).as(ExitCode.Error)
-          case Right(coord) => GetHandler.run(coord, fqn, javaHome, extraRepos)
-        }
+      (coordArg, symbolArg, memberLimitOpt, hideInheritedOpt, groupInheritedOpt, javaHomeOpt, extraReposOpt).mapN {
+        (rawCoord, fqn, limit, hideInherited, groupInherited, javaHome, extraRepos) =>
+          parseAndResolve(rawCoord, extraRepos).flatMap {
+            case Left(err)    => IO.blocking(System.err.println(err)).as(ExitCode.Error)
+            case Right(coord) => GetHandler.run(coord, fqn, javaHome, extraRepos, limit, hideInherited, groupInherited)
+          }
       }
     }
 

--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -91,17 +91,66 @@ object GetFormatter:
   )(using ctx: Context): Option[String] =
     sym match
       case cls: ClassSymbol =>
-        val raw =
-          if hideInherited then cls.declarations.filter(PublicApiFilter.isPublic).toList
-          else SymbolResolver.collectClassMembers(cls).filter(PublicApiFilter.isPublic)
-        val members = raw.map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
-        if members.isEmpty then None
-        else limit match
-          case Some(n) if members.length > n =>
-            Some(members.take(n).mkString("\n") + s"\n// … ${members.length - n} more members")
-          case _ =>
-            Some(members.mkString("\n"))
+        // --hide-inherited silently wins over --group-inherited
+        if hideInherited then renderFlatMembers(cls.declarations.filter(PublicApiFilter.isPublic).toList, limit)
+        else if groupInherited then renderGroupedMembers(cls, limit)
+        else renderFlatMembers(SymbolResolver.collectClassMembers(cls).filter(PublicApiFilter.isPublic), limit)
       case _ => None
+
+  private def formatMember(m: TermOrTypeSymbol)(using Context): String =
+    TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim
+
+  private def renderFlatMembers(raw: List[TermOrTypeSymbol], limit: Option[Int])(using Context): Option[String] =
+    val members = raw.map(formatMember)
+    if members.isEmpty then None
+    else limit match
+      case Some(n) if members.length > n =>
+        Some(members.take(n).mkString("\n") + s"\n// … ${members.length - n} more members")
+      case _ =>
+        Some(members.mkString("\n"))
+
+  private val universalBaseClasses = Set("scala.Any", "scala.AnyRef", "java.lang.Object")
+
+  private def renderGroupedMembers(cls: ClassSymbol, limit: Option[Int])(using ctx: Context): Option[String] =
+    val linearization =
+      try cls.linearization
+      catch case _: Exception => List(cls)
+    val seen     = scala.collection.mutable.Set.empty[TermOrTypeSymbol]
+    val sections = List.newBuilder[(String, List[String])]
+    linearization.filterNot(k => universalBaseClasses.contains(k.displayFullName)).foreach { klass =>
+      val decls =
+        try klass.declarations
+        catch case _: Exception => Nil
+      val members = decls.flatMap {
+        case decl: TermOrTypeSymbol if PublicApiFilter.isPublic(decl) && !seen.contains(decl) =>
+          val dominated = decl.overridingSymbol(cls).exists(_ != decl)
+          if !dominated then
+            seen += decl
+            Some(formatMember(decl))
+          else None
+        case _ => None
+      }.toList
+      if members.nonEmpty then
+        val label =
+          if klass == cls then s"Declared on ${klass.name}"
+          else s"Inherited from ${klass.name}"
+        sections += ((label, members))
+    }
+    val all = sections.result()
+    if all.isEmpty then None
+    else
+      val totalMembers = all.map(_._2.length).sum
+      val needsTruncation = limit.exists(totalMembers > _)
+      val sb = new StringBuilder
+      var remaining = limit.getOrElse(Int.MaxValue)
+      for (header, members) <- all if remaining > 0 do
+        val take = members.take(remaining)
+        sb.append(s"// $header\n")
+        sb.append(take.mkString("\n")).append('\n')
+        remaining -= take.length
+      if needsTruncation then
+        sb.append(s"// … ${totalMembers - limit.get} more members\n")
+      Some(sb.toString.trim)
 
   private def renderCompanion(sym: Symbol)(using ctx: Context): Option[String] =
     sym match

--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -4,12 +4,18 @@ import tastyquery.Contexts.Context
 import tastyquery.Symbols.{ClassSymbol, Symbol, TermOrTypeSymbol, TermSymbol, TypeSymbol}
 
 object GetFormatter:
-  def formatSymbol(sym: Symbol, docstring: Option[String] = None)(using ctx: Context): String =
+  def formatSymbol(
+      sym: Symbol,
+      docstring: Option[String] = None,
+      limit: Option[Int] = None,
+      hideInherited: Boolean = false,
+      groupInherited: Boolean = false
+  )(using ctx: Context): String =
     val fqn       = sym.displayFullName
     val signature = TypePrinter.printSymbolSignature(sym)
     val flags     = renderFlags(sym)
     val origin    = renderOrigin(sym)
-    val members   = renderMembers(sym)
+    val members   = renderMembers(sym, limit, hideInherited, groupInherited)
     val companion = renderCompanion(sym)
     val subtypes  = renderSubtypes(sym)
 
@@ -26,9 +32,16 @@ object GetFormatter:
     subtypes.foreach(s => sb.append(s"**Known subtypes:** $s\n"))
     sb.toString
 
-  def formatGetResult(@annotation.unused fqn: String, symbols: List[Symbol], docstring: Option[String] = None)(using ctx: Context): String =
+  def formatGetResult(
+      @annotation.unused fqn: String,
+      symbols: List[Symbol],
+      docstring: Option[String] = None,
+      limit: Option[Int] = None,
+      hideInherited: Boolean = false,
+      groupInherited: Boolean = false
+  )(using ctx: Context): String =
     symbols.zipWithIndex.map { (sym, i) =>
-      formatSymbol(sym, if i == 0 then docstring else None)
+      formatSymbol(sym, if i == 0 then docstring else None, limit, hideInherited, groupInherited)
     }.mkString("\n\n---\n\n")
 
   private def cleanDocstring(raw: String): String =
@@ -70,7 +83,12 @@ object GetFormatter:
       case owner: ClassSymbol => owner.displayFullName
       case _                  => sym.displayFullName
 
-  private def renderMembers(sym: Symbol)(using ctx: Context): Option[String] =
+  private def renderMembers(
+      sym: Symbol,
+      limit: Option[Int],
+      hideInherited: Boolean,
+      groupInherited: Boolean
+  )(using ctx: Context): Option[String] =
     sym match
       case cls: ClassSymbol =>
         val members = SymbolResolver.collectClassMembers(cls)

--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -91,9 +91,10 @@ object GetFormatter:
   )(using ctx: Context): Option[String] =
     sym match
       case cls: ClassSymbol =>
-        val members = SymbolResolver.collectClassMembers(cls)
-          .filter(PublicApiFilter.isPublic)
-          .map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
+        val raw =
+          if hideInherited then cls.declarations.filter(PublicApiFilter.isPublic).toList
+          else SymbolResolver.collectClassMembers(cls).filter(PublicApiFilter.isPublic)
+        val members = raw.map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
         if members.isEmpty then None
         else limit match
           case Some(n) if members.length > n =>

--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -94,7 +94,12 @@ object GetFormatter:
         val members = SymbolResolver.collectClassMembers(cls)
           .filter(PublicApiFilter.isPublic)
           .map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
-        if members.isEmpty then None else Some(members.mkString("\n"))
+        if members.isEmpty then None
+        else limit match
+          case Some(n) if members.length > n =>
+            Some(members.take(n).mkString("\n") + s"\n// … ${members.length - n} more members")
+          case _ =>
+            Some(members.mkString("\n"))
       case _ => None
 
   private def renderCompanion(sym: Symbol)(using ctx: Context): Option[String] =

--- a/lib/src/cellar/handlers/GetHandler.scala
+++ b/lib/src/cellar/handlers/GetHandler.scala
@@ -14,14 +14,17 @@ object GetHandler:
       coord: MavenCoordinate,
       fqn: String,
       javaHome: Option[Path] = None,
-      extraRepositories: Seq[Repository] = Seq.empty
+      extraRepositories: Seq[Repository] = Seq.empty,
+      limit: Option[Int] = None,
+      hideInherited: Boolean = false,
+      groupInherited: Boolean = false
   )(using Console[IO]): IO[ExitCode] =
     val program =
       for
         jreClasspath <- javaHome.fold(JreClasspath.jrtPath())(JreClasspath.jrtPath)
         result   <- ContextResource.makeFromCoord(coord, jreClasspath, extraRepositories).use { (ctx, classpath) =>
           given Context = ctx
-          runCore(fqn, classpath, Some(coord))
+          runCore(fqn, classpath, Some(coord), limit, hideInherited, groupInherited)
         }
       yield result
 
@@ -32,7 +35,10 @@ object GetHandler:
   def runCore(
       fqn: String,
       classpath: Classpath,
-      coord: Option[MavenCoordinate]
+      coord: Option[MavenCoordinate],
+      limit: Option[Int] = None,
+      hideInherited: Boolean = false,
+      groupInherited: Boolean = false
   )(using Context, Console[IO]): IO[ExitCode] =
     SymbolResolver.resolve(fqn).flatMap {
       case LookupResult.Found(symbols) =>
@@ -40,7 +46,7 @@ object GetHandler:
         for
           _         <- warnShadedDuplicate(fqn, classpath)
           docstring <- coord.fold(IO.pure(Option.empty[String]))(c => IO.blocking(DocstringExtractor.extract(jars.map(_.toNioPath), c, fqn)))
-          formatted <- IO.blocking(GetFormatter.formatGetResult(fqn, symbols, docstring))
+          formatted <- IO.blocking(GetFormatter.formatGetResult(fqn, symbols, docstring, limit, hideInherited, groupInherited))
           _         <- Console[IO].println(formatted)
           _         <- warnScala2(symbols)
         yield ExitCode.Success

--- a/lib/src/cellar/handlers/ProjectGetHandler.scala
+++ b/lib/src/cellar/handlers/ProjectGetHandler.scala
@@ -12,10 +12,13 @@ object ProjectGetHandler:
       module: Option[String],
       javaHome: Option[Path] = None,
       noCache: Boolean = false,
+      limit: Option[Int] = None,
+      hideInherited: Boolean = false,
+      groupInherited: Boolean = false,
       cwd: Option[Path] = None,
       config: Config = Config.global
   )(using Console[IO]): IO[ExitCode] =
     ProjectHandler.run(javaHome, cwd, module, noCache, config) { (ctx, classpath, _) =>
       given Context = ctx
-      GetHandler.runCore(fqn, classpath, coord = None)
+      GetHandler.runCore(fqn, classpath, coord = None, limit, hideInherited, groupInherited)
     }

--- a/lib/test/src/cellar/GetFormatterTest.scala
+++ b/lib/test/src/cellar/GetFormatterTest.scala
@@ -196,6 +196,33 @@ class GetFormatterTest extends CatsEffectSuite:
       }
     }
 
+  test("formatSymbol --group-inherited adds section headers by declaring class"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        // CellarLeaf → CellarMid → CellarOuter
+        val cls    = ctx.findStaticClass("cellar.fixture.scala3.CellarLeaf")
+        val output = GetFormatter.formatSymbol(cls, groupInherited = true)
+        assert(output.contains("// Declared on CellarLeaf"), s"Expected declared section in:\n$output")
+        assert(output.contains("// Inherited from CellarMid"), s"Expected CellarMid section in:\n$output")
+        assert(output.contains("// Inherited from CellarOuter"), s"Expected CellarOuter section in:\n$output")
+        assert(output.contains("leafMethod"), s"Expected leafMethod in:\n$output")
+        assert(output.contains("midMethod"), s"Expected midMethod in:\n$output")
+      }
+    }
+
+  test("formatSymbol --hide-inherited wins over --group-inherited"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        val cls    = ctx.findStaticClass("cellar.fixture.scala3.CellarLeaf")
+        val output = GetFormatter.formatSymbol(cls, hideInherited = true, groupInherited = true)
+        assert(output.contains("leafMethod"), s"Expected leafMethod in:\n$output")
+        assert(!output.contains("midMethod"), s"Unexpected midMethod in:\n$output")
+        assert(!output.contains("Inherited from"), s"Unexpected section header in:\n$output")
+      }
+    }
+
   test("formatSymbol --limit caps member count and shows note"):
     withCtx { ctx =>
       IO.blocking {

--- a/lib/test/src/cellar/GetFormatterTest.scala
+++ b/lib/test/src/cellar/GetFormatterTest.scala
@@ -182,6 +182,20 @@ class GetFormatterTest extends CatsEffectSuite:
       }
     }
 
+  test("formatSymbol --hide-inherited shows only declared members"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        // CellarLeaf declares leafMethod; midMethod and innerMethod are inherited
+        val cls    = ctx.findStaticClass("cellar.fixture.scala3.CellarLeaf")
+        val full   = GetFormatter.formatSymbol(cls)
+        val hidden = GetFormatter.formatSymbol(cls, hideInherited = true)
+        assert(full.contains("midMethod"), s"Expected midMethod in full output: $full")
+        assert(hidden.contains("leafMethod"), s"Expected leafMethod in hidden output: $hidden")
+        assert(!hidden.contains("midMethod"), s"Unexpected midMethod in hidden output: $hidden")
+      }
+    }
+
   test("formatSymbol --limit caps member count and shows note"):
     withCtx { ctx =>
       IO.blocking {

--- a/lib/test/src/cellar/GetFormatterTest.scala
+++ b/lib/test/src/cellar/GetFormatterTest.scala
@@ -181,3 +181,19 @@ class GetFormatterTest extends CatsEffectSuite:
         assertEquals(processCount, 3, s"Expected 3 process overloads in:\n$output")
       }
     }
+
+  test("formatSymbol --limit caps member count and shows note"):
+    withCtx { ctx =>
+      IO.blocking {
+        given Context = ctx
+        val cls    = ctx.findStaticClass("cellar.fixture.scala3.CellarOverloaded")
+        val full   = GetFormatter.formatSymbol(cls)
+        val limited = GetFormatter.formatSymbol(cls, limit = Some(2))
+        // Full output has at least 3 process overloads + unique
+        val fullCount = full.linesIterator.count(l => l.contains("def process(") || l.contains("def unique"))
+        assert(fullCount >= 3, s"Expected >= 3 members in full, got $fullCount in:\n$full")
+        // Limited output has exactly 2 member lines in the code block
+        assert(limited.contains("… "), s"Expected truncation note in: $limited")
+        assert(limited.contains("more members"), s"Expected 'more members' in: $limited")
+      }
+    }

--- a/skills/cellar/SKILL.md
+++ b/skills/cellar/SKILL.md
@@ -19,7 +19,9 @@ Query the current project's code and all its dependencies. Cellar auto-detects t
 - scala-cli projects: omit `--module`
 - `--no-cache`: skip classpath cache, re-extract from build tool
 - `--java-home <path>`: override JRE classpath
-- `-l`, `--limit <N>`: max results for `list`/`search` (default: 50)
+- `-l`, `--limit <N>`: max results for `list`/`search` (default: 50), max members for `get`
+- `--hide-inherited`: show only members declared on the type itself (`get` commands)
+- `--group-inherited`: group members by declaring type with section headers (`get` commands)
 
 ## External commands (query arbitrary Maven coordinates)
 


### PR DESCRIPTION
### Summary
* Add `--limit N` flag to `get`/`get-external` — caps the member listing at N entries and appends a "… M more members" note, matching the existing --limit on list/search
* Add `--hide-inherited flag` — shows only members declared directly on the type, filtering out everything from supertypes (e.g. cats.Monad goes from ~50 members to ~10). Alternative names for the flag to consider: `--declared-only`, `--declared`.
* Add `--group-inherited` flag — groups members by declaring class with `// Declared on Monad` / `// Inherited from FlatMap` section headers, ordered by linearization

All three flags default to off/unlimited , preserving current behavior. `--hide-inherited ` silently wins when combined with `--group-inherited`

### Structure
The implementation is split across 5 commits:

* Plumbing — wires all three flags through CLI → handlers → formatter with no behavior change
* `--limit` — rendering logic in `renderFlatMembers`
* `--hide-inherited` — switches to `cls.declarations` instead of full linearization walk
* `--group-inherited` — `renderGroupedMembers` walks linearization, emits section headers
* Docs — updates README and SKILL with the new flags

### Test plan
* `formatSymbol` `--limit` caps member count and shows note
* `formatSymbol` `--hide-inherited` shows only declared members
* `formatSymbol` `--group-inherited` adds section headers by declaring class
* `formatSymbol` `--hide-inherited` wins over `--group-inherited`
 
All existing `GetFormatterTest` cases still pass (no default behavior change)
Full `lib.test` green (372 tests)

🤖 Co-authored by [Claude Code](https://claude.com/claude-code)