### PR TITLE
Deduplicate repeated patterns across handlers and build tools

### DIFF
--- a/lib/src/cellar/GetFormatter.scala
+++ b/lib/src/cellar/GetFormatter.scala
@@ -109,15 +109,13 @@ object GetFormatter:
       case _ =>
         Some(members.mkString("\n"))
 
-  private val universalBaseClasses = Set("scala.Any", "scala.AnyRef", "java.lang.Object")
-
   private def renderGroupedMembers(cls: ClassSymbol, limit: Option[Int])(using ctx: Context): Option[String] =
     val linearization =
       try cls.linearization
       catch case _: Exception => List(cls)
     val seen     = scala.collection.mutable.Set.empty[TermOrTypeSymbol]
     val sections = List.newBuilder[(String, List[String])]
-    linearization.filterNot(k => universalBaseClasses.contains(k.displayFullName)).foreach { klass =>
+    linearization.filterNot(k => SymbolResolver.universalBaseClasses.contains(k.displayFullName)).foreach { klass =>
       val decls =
         try klass.declarations
         catch case _: Exception => Nil
@@ -158,7 +156,7 @@ object GetFormatter:
         cls.companionClass.flatMap { companion =>
           val members = companion.declarations
             .filter(m => PublicApiFilter.isPublic(m))
-            .map(m => TypePrinter.printSymbolSignatureSafe(m).linesIterator.mkString(" ").trim)
+            .map(formatMember)
           if members.isEmpty then None else Some(members.mkString(", "))
         }
       case _ => None

--- a/lib/src/cellar/SymbolResolver.scala
+++ b/lib/src/cellar/SymbolResolver.scala
@@ -170,7 +170,7 @@ object SymbolResolver:
       i += 1
     best
 
-  private val universalBaseClasses = Set("scala.Any", "scala.AnyRef", "java.lang.Object")
+  private[cellar] val universalBaseClasses = Set("scala.Any", "scala.AnyRef", "java.lang.Object")
 
   /**
    * Walk the linearization (MRO) of a class, collecting all declarations.

--- a/lib/src/cellar/build/BuildTool.scala
+++ b/lib/src/cellar/build/BuildTool.scala
@@ -2,6 +2,7 @@ package cellar.build
 
 import cats.effect.IO
 import cellar.CellarError
+import cellar.process.ProcessRunner
 import fs2.io.file.Path
 
 trait BuildTool:
@@ -14,3 +15,10 @@ trait BuildTool:
     module match
       case Some(m) => IO.pure(m)
       case None    => IO.raiseError(CellarError.ModuleRequired(kind))
+
+  protected def gitOrDiskFingerprint(cwd: Path, gitPatterns: List[String], fromDisk: IO[List[Path]]): IO[List[Path]] =
+    ProcessRunner.run("git", "ls-files" :: gitPatterns, Some(cwd)).flatMap { result =>
+      if result.exitCode == 0 then
+        IO.pure(result.stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList)
+      else fromDisk
+    }

--- a/lib/src/cellar/build/MillBuildTool.scala
+++ b/lib/src/cellar/build/MillBuildTool.scala
@@ -65,19 +65,8 @@ class MillBuildTool(cwd: Path, config: MillConfig) extends BuildTool:
             Path(path).some.filterA(Files[IO].isDirectory(_))
 
   def fingerprintFiles: IO[List[Path]] =
-    Files[IO].isDirectory(cwd.resolve(".git")).ifM(
-      ifTrue = fingerprintFromGit,
-      ifFalse = fingerprintFromDisk
-    )
-
-  private def fingerprintFromGit: IO[List[Path]] =
-    val patterns = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", "mill-build/**", ".mill-version")
-    ProcessRunner.run("git", "ls-files" :: patterns, Some(cwd)).flatMap { result =>
-      if result.exitCode == 0 then
-        IO.pure(result.stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList)
-      else
-        fingerprintFromDisk
-    }
+    val gitPatterns = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", "mill-build/**", ".mill-version")
+    gitOrDiskFingerprint(cwd, gitPatterns, fingerprintFromDisk)
 
   private def fingerprintFromDisk: IO[List[Path]] =
     val candidates = List("build.mill", "build.sc", "build.mill.yaml", "build.yaml", ".mill-version")

--- a/lib/src/cellar/build/SbtBuildTool.scala
+++ b/lib/src/cellar/build/SbtBuildTool.scala
@@ -44,18 +44,8 @@ class SbtBuildTool(cwd: Path, config: SbtConfig) extends BuildTool:
     }
 
   def fingerprintFiles: IO[List[Path]] =
-    Files[IO].isDirectory(cwd.resolve(".git")).ifM(
-      ifTrue = fingerprintFromGit,
-      ifFalse = fingerprintFromDisk
-    )
-
-  private def fingerprintFromGit: IO[List[Path]] =
-    val patterns = List("build.sbt", "project/*.sbt", "project/*.scala", "project/build.properties")
-    ProcessRunner.run("git", "ls-files" :: patterns, Some(cwd)).flatMap {
-      case result if result.exitCode == 0 =>
-        IO.pure(result.stdout.linesIterator.filter(_.nonEmpty).map(cwd.resolve).toList)
-      case _ => fingerprintFromDisk
-    }
+    val gitPatterns = List("build.sbt", "project/*.sbt", "project/*.scala", "project/build.properties")
+    gitOrDiskFingerprint(cwd, gitPatterns, fingerprintFromDisk)
 
   private def fingerprintFromDisk: IO[List[Path]] =
     val candidates = List("build.sbt", "project/build.properties", "project/plugins.sbt")

--- a/lib/src/cellar/handlers/DepsHandler.scala
+++ b/lib/src/cellar/handlers/DepsHandler.scala
@@ -17,7 +17,6 @@ object DepsHandler:
         _         <- Console[IO].println(formatted)
       yield ExitCode.Success
 
-    program.handleErrorWith {
-      case e: CellarError => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
-      case e: Throwable   => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
+    program.handleErrorWith { case e: Throwable =>
+      Console[IO].errorln(e.getMessage).as(ExitCode.Error)
     }

--- a/lib/src/cellar/handlers/GetSourceHandler.scala
+++ b/lib/src/cellar/handlers/GetSourceHandler.scala
@@ -50,9 +50,8 @@ object GetSourceHandler:
         }
       yield result
 
-    program.handleErrorWith {
-      case e: CellarError => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
-      case e: Throwable   => Console[IO].errorln(e.getMessage).as(ExitCode.Error)
+    program.handleErrorWith { case e: Throwable =>
+      Console[IO].errorln(e.getMessage).as(ExitCode.Error)
     }
 
   /**


### PR DESCRIPTION
Closes #51

## Summary

- `universalBaseClasses` — was defined identically in both `SymbolResolver` and `GetFormatter`; now lives in `SymbolResolver` (`private[cellar]`) and referenced from `GetFormatter`
- `GetFormatter.renderCompanion` — replaced inline `TypePrinter.printSymbolSignatureSafe(...).linesIterator.mkString(" ").trim` with the existing `formatMember` helper
- `DepsHandler`, `GetSourceHandler` — collapsed two identical `handleErrorWith` cases into one `case e: Throwable =>`
- `BuildTool` — extracted `gitOrDiskFingerprint` helper; `MillBuildTool` and `SbtBuildTool` now share the git-ls-files-with-disk-fallback logic instead of duplicating it; also removes the TOCTOU `isDirectory(.git)` pre-check (git exit code is the correct signal, and worktrees have `.git` as a file)

## Test plan

- [ ] `./mill lib.compile` passes
- [ ] `./mill lib.test` passes