### PR TITLE
Fix NearMatchFinder suggesting the exact FQN the user already provided

### DIFF
--- a/lib/src/cellar/NearMatchFinder.scala
+++ b/lib/src/cellar/NearMatchFinder.scala
@@ -16,6 +16,7 @@ object NearMatchFinder:
         .flatMap(entry => try ctx.findSymbolsByClasspathEntry(entry).toList catch case _: Throwable => Nil)
         .filter(sym => PublicApiFilter.isPublic(sym) && sym.name.toString.toLowerCase == lowerName)
         .map(_.displayFullName)
+        .filter(_ != fqn)
         .take(10)
         .toList
     }

--- a/lib/test/src/cellar/NearMatchFinderTest.scala
+++ b/lib/test/src/cellar/NearMatchFinderTest.scala
@@ -62,3 +62,16 @@ class NearMatchFinderTest extends CatsEffectSuite:
         assert(matches.exists(_.endsWith("CellarA")), s"Expected CellarA: $matches")
       }
     }
+
+  List(
+    "cellar.fixture.scala3.CellarADT",
+    "cellar.fixture.scala3.CellarB$",
+  ).foreach { fqn =>
+    test(s"findNearMatches does not suggest $fqn back to the user"):
+      withCtxAndCp { (ctx, cp) =>
+        given Context = ctx
+        NearMatchFinder.findNearMatches(fqn, cp).map { matches =>
+          assert(!matches.contains(fqn), s"Expected $fqn to be excluded from near matches, got: $matches")
+        }
+      }
+  }


### PR DESCRIPTION
Fixes #54.

## Summary

- Filter out near-match candidates whose `displayFullName` equals the original `fqn` before building the suggestion list
- Add parameterized tests covering both a plain type FQN and a module class `$` form (the exact pattern from the issue)