### PR TITLE
Suggest latest version in SymbolNotFound when no near matches

### DIFF
--- a/lib/src/cellar/CellarError.scala
+++ b/lib/src/cellar/CellarError.scala
@@ -26,8 +26,10 @@ object CellarError:
       extends CellarError:
     override def getMessage: String =
       val base = s"Symbol '$fqn' not found in '${coord.render}'."
-      if nearMatches.isEmpty then base
-      else s"$base Did you mean one of: ${nearMatches.mkString(", ")}?"
+      if nearMatches.nonEmpty then s"$base Did you mean one of: ${nearMatches.mkString(", ")}?"
+      else if coord.version != "latest" then
+        s"$base\nTry '${coord.copy(version = "latest").render}' if the symbol was introduced in a newer version."
+      else base
 
   final case class PartialResolution(fqn: String, coord: Option[MavenCoordinate], resolvedFqn: String, missingMember: String)
       extends CellarError:

--- a/lib/test/src/cellar/CellarErrorTest.scala
+++ b/lib/test/src/cellar/CellarErrorTest.scala
@@ -19,6 +19,15 @@ class CellarErrorTest extends munit.FunSuite:
     val e = CellarError.SymbolNotFound("Foo", coord, Nil)
     assert(!e.getMessage.contains("Did you mean"))
 
+  test("SymbolNotFound with empty nearMatches and non-latest version suggests latest"):
+    val e = CellarError.SymbolNotFound("Foo", coord, Nil)
+    assert(e.getMessage.contains("org.example:lib:latest"))
+
+  test("SymbolNotFound with empty nearMatches and version=latest does not add a Try hint"):
+    val latestCoord = MavenCoordinate("org.example", "lib", "latest")
+    val e           = CellarError.SymbolNotFound("Foo", latestCoord, Nil)
+    assert(!e.getMessage.contains("Try"))
+
   test("SymbolNotFound with nearMatches lists all of them"):
     val e = CellarError.SymbolNotFound("Foo", coord, List("bar.Foo", "baz.Foo"))
     assert(e.getMessage.contains("bar.Foo"))

--- a/lib/test/src/cellar/CellarErrorTest.scala
+++ b/lib/test/src/cellar/CellarErrorTest.scala
@@ -26,7 +26,7 @@ class CellarErrorTest extends munit.FunSuite:
   test("SymbolNotFound with empty nearMatches and version=latest does not add a Try hint"):
     val latestCoord = MavenCoordinate("org.example", "lib", "latest")
     val e           = CellarError.SymbolNotFound("Foo", latestCoord, Nil)
-    assert(!e.getMessage.contains("Try"))
+    assert(!e.getMessage.contains("Try 'org.example:lib:latest'"))
 
   test("SymbolNotFound with nearMatches lists all of them"):
     val e = CellarError.SymbolNotFound("Foo", coord, List("bar.Foo", "baz.Foo"))


### PR DESCRIPTION
Fixes #59.

## Summary
- In `CellarError.SymbolNotFound.getMessage`, when `nearMatches` is empty and the coordinate version is not already `latest`, appends a hint suggesting `group:artifact:latest`
- Adds two tests: one verifying the hint appears for versioned coordinates, one verifying it is suppressed when already using `latest`

## Test plan
- [ ] `./mill lib.test` passes (372/372)