### PR TITLE
Remove leftover dev script and stale references

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,3 @@ Examples are testing match exhaustivity, typesystem etc.
 ## Documentation
 
 When adding or modifying CLI commands, flags, or config options, update `README.md` accordingly.
-
-## Development history
-
-All plans, decision and architecture designs are available in ai/ folder

--- a/README.md
+++ b/README.md
@@ -319,8 +319,6 @@ java -jar out/cli/assembly.dest/out.jar get-external org.typelevel:cats-core_3:2
 # Native image (GraalVM)
 ./mill cli.nativeImage
 
-# Wrapper script (for development)
-./scripts/cellar get-external org.typelevel:cats-core_3:2.10.0 cats.Monad
 ```
 
 ### Running tests

--- a/scripts/cellar
+++ b/scripts/cellar
@@ -1,2 +1,0 @@
-#!/bin/sh
-exec java $JAVA_OPTS -jar "/home/rochala/Projects/cellar/out/cli/assembly.dest/out.jar" "$@"


### PR DESCRIPTION
Closes #40

## Summary
- Delete `scripts/cellar` — dev wrapper with hardcoded local absolute path, not intended to be checked in
- Remove corresponding "Wrapper script" example from `README.md`
- Remove stale "Development history" section from `CLAUDE.md` referencing the non-existent (gitignored) `ai/` folder