### PR TITLE
Publish lib + cli modules to Maven Central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,7 +97,7 @@ jobs:
           path: ${{ env.JAR }}
 
   publish-maven:
-    name: Publish lib to Maven Central
+    name: Publish lib + cli to Maven Central
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -113,7 +113,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Publish to Maven Central
-        run: ./mill lib.publishSonatypeCentral
+        run: ./mill lib.publishSonatypeCentral cli.publishSonatypeCentral
         env:
           CELLAR_VERSION: v${{ inputs.version }}
           MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -69,6 +71,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
@@ -100,6 +104,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: main
 
       - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,32 @@ jobs:
           name: jar
           path: ${{ env.JAR }}
 
+  publish-maven:
+    name: Publish lib to Maven Central
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Publish to Maven Central
+        run: ./mill lib.publishSonatypeCentral
+        env:
+          CELLAR_VERSION: v${{ inputs.version }}
+          MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MILL_PGP_SECRET_BASE64: ${{ secrets.PGP_SECRET }}
+          MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+
   release:
     name: Publish Release
-    needs: [build, jar]
+    needs: [build, jar, publish-maven]
     runs-on: ubuntu-latest
     # OIDC token for cosign keyless signing; write access for release publishing
     permissions:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,7 +16,7 @@ This document describes how to cut a release, what artifacts are produced, and h
 3. The workflow:
    - Builds GraalVM native binaries for all supported platforms in parallel.
    - Packages each binary into a platform-appropriate archive.
-   - Publishes the `lib` module to Maven Central as `org.virtuslab:cellar-lib_3:<version>`.
+   - Publishes the `lib` and `cli` modules to Maven Central as `org.virtuslab:cellar-lib_3:<version>` and `org.virtuslab:cellar-cli_3:<version>`.
    - Generates a SHA256 checksum file.
    - Signs the checksum file using cosign keyless (OIDC).
    - Updates `flake.nix` with the new version and SRI hashes, commits to `main`.
@@ -47,14 +47,22 @@ Each GitHub Release contains:
 | `checksums.txt` | SHA256 checksums for all archives |
 | `checksums.txt.bundle` | Sigstore bundle for the checksum file |
 
-## Maven Central artifact
+## Maven Central artifacts
 
-The `lib` module is published as `org.virtuslab:cellar-lib_3:<version>`. This is what coursier resolves when a user runs `cs install cellar` — the [coursier/apps](https://github.com/coursier/apps) descriptor for cellar reads `maven-metadata.xml` for this coordinate to determine the latest version, then downloads the matching native binary from this repo's GitHub Release.
+Two modules are published per release:
 
-The library is also independently usable as a Scala 3 dependency:
+| Coordinate | Contents |
+|---|---|
+| `org.virtuslab:cellar-lib_3:<version>` | The dependency-API library — symbol resolver, formatters, Maven coordinate parsing, etc. |
+| `org.virtuslab:cellar-cli_3:<version>` | The CLI driver (`cellar.cli.CellarApp` and friends). Regular Scala library JAR — does **not** include the bundled JRE blob used by the GraalVM native image. |
+
+`cellar-lib` is what coursier resolves for `cs install cellar` — the [coursier/apps](https://github.com/coursier/apps) descriptor reads `maven-metadata.xml` for `cellar-lib_3` to determine the latest version, then downloads the matching native binary from this repo's GitHub Release.
+
+Both modules are independently usable as Scala 3 dependencies:
 
 ```scala
 mvn"org.virtuslab::cellar-lib:<version>"
+mvn"org.virtuslab::cellar-cli:<version>"
 ```
 
 ### Required GitHub secrets

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -15,9 +15,12 @@ This document describes how to cut a release, what artifacts are produced, and h
 3. The [Release workflow](.github/workflows/release.yml) runs automatically and:
    - Builds GraalVM native binaries for all supported platforms in parallel.
    - Packages each binary into a platform-appropriate archive.
+   - Publishes the `lib` module to Maven Central as `org.virtuslab:cellar-lib_3:<version>`.
    - Generates a SHA256 checksum file.
    - Signs the checksum file using cosign keyless (OIDC).
    - Publishes a GitHub Release with all artifacts attached.
+
+The Maven publish runs in parallel with the binary builds and blocks the GitHub Release; if Sonatype rejects the upload (e.g. duplicate version, namespace mismatch, signature failure), no GitHub Release is created.
 
 No container images are built or published by this release flow.
 
@@ -40,6 +43,31 @@ Each GitHub Release contains:
 | `cellar-<version>-<os>-<arch>.tar.gz` | Archive containing the `cellar` binary and `README.md` |
 | `checksums.txt` | SHA256 checksums for all archives |
 | `checksums.txt.bundle` | Sigstore bundle for the checksum file |
+
+## Maven Central artifact
+
+The `lib` module is published as `org.virtuslab:cellar-lib_3:<version>`. This is what coursier resolves when a user runs `cs install cellar` — the [coursier/apps](https://github.com/coursier/apps) descriptor for cellar reads `maven-metadata.xml` for this coordinate to determine the latest version, then downloads the matching native binary from this repo's GitHub Release.
+
+The library is also independently usable as a Scala 3 dependency:
+
+```scala
+mvn"org.virtuslab::cellar-lib:<version>"
+```
+
+### Required GitHub secrets
+
+The Maven publish step in `.github/workflows/release.yml` reads four repository secrets:
+
+| Secret | Purpose |
+|---|---|
+| `SONATYPE_USERNAME` | Central Portal user-token name (generated at central.sonatype.com) |
+| `SONATYPE_PASSWORD` | Central Portal user-token value |
+| `PGP_SECRET` | Base64-encoded ASCII-armored PGP private key (artifact signatures) |
+| `PGP_PASSPHRASE` | Passphrase for the PGP key |
+
+Mill reads these via `MILL_SONATYPE_USERNAME` / `MILL_SONATYPE_PASSWORD` / `MILL_PGP_SECRET_BASE64` / `MILL_PGP_PASSPHRASE` environment variables.
+
+The PGP signing here is unrelated to the cosign signing of `checksums.txt` — Sonatype Central mandates `.asc` signatures on every uploaded artifact (`.jar`, `.pom`, `-sources.jar`, `-javadoc.jar`), while cosign covers the GitHub Release assets.
 
 ## Verifying checksums
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,22 +5,25 @@ This document describes how to cut a release, what artifacts are produced, and h
 ## Cutting a release
 
 1. Ensure the `main` branch is in a releasable state and tests pass.
-2. Push a version tag (the workflow triggers on `v*`):
+2. Trigger the [Release workflow](.github/workflows/release.yml) manually — either via the GitHub Actions UI ("Run workflow" → enter version without `v` prefix) or via `gh`:
 
    ```sh
-   git tag v1.2.3
-   git push origin v1.2.3
+   gh workflow run release.yml -f version=1.2.3
    ```
 
-3. The [Release workflow](.github/workflows/release.yml) runs automatically and:
+   All jobs check out `main`, so the dispatch ref is irrelevant.
+
+3. The workflow:
    - Builds GraalVM native binaries for all supported platforms in parallel.
    - Packages each binary into a platform-appropriate archive.
    - Publishes the `lib` module to Maven Central as `org.virtuslab:cellar-lib_3:<version>`.
    - Generates a SHA256 checksum file.
    - Signs the checksum file using cosign keyless (OIDC).
+   - Updates `flake.nix` with the new version and SRI hashes, commits to `main`.
+   - Creates and pushes a `v<version>` git tag.
    - Publishes a GitHub Release with all artifacts attached.
 
-The Maven publish runs in parallel with the binary builds and blocks the GitHub Release; if Sonatype rejects the upload (e.g. duplicate version, namespace mismatch, signature failure), no GitHub Release is created.
+The Maven publish runs in parallel with the binary builds and blocks the GitHub Release; if Sonatype rejects the upload (e.g. duplicate version, namespace mismatch, signature failure), no GitHub Release is created and no tag is pushed.
 
 No container images are built or published by this release flow.
 

--- a/build.mill
+++ b/build.mill
@@ -6,6 +6,7 @@ import mill.scalalib._
 import mill.scalalib.Assembly
 import mill.scalalib.publish._
 import mill.javalib.NativeImageModule
+import mill.javalib.SonatypeCentralPublishModule
 import com.goyeau.mill.scalafix.ScalafixModule
 
 trait CommonScalaModule extends ScalaModule with ScalafixModule {
@@ -14,8 +15,22 @@ trait CommonScalaModule extends ScalaModule with ScalafixModule {
   def scalacOptions = Seq("-deprecation", "-feature", "-Wunused:all")
 }
 
-// Minimal PomSettings for test fixtures
-object lib extends CommonScalaModule {
+def cellarVersion: T[String] = Task.Input {
+  sys.env.getOrElse("CELLAR_VERSION", "0.1.0-SNAPSHOT").stripPrefix("v")
+}
+
+object lib extends CommonScalaModule with SonatypeCentralPublishModule {
+  def publishVersion = cellarVersion()
+  def artifactName = "cellar-lib"
+  def pomSettings = PomSettings(
+    description    = "Programmatic access to JVM dependency APIs (Scala 3, Scala 2, Java)",
+    organization   = "org.virtuslab",
+    url            = "https://github.com/VirtusLab/cellar",
+    licenses       = Seq(License.`MPL-2.0`),
+    versionControl = VersionControl.github("VirtusLab", "cellar"),
+    developers     = Seq(Developer("rochala", "Jakub Rochala", "https://github.com/rochala"))
+  )
+
   def mvnDeps = Seq(
     mvn"org.typelevel::cats-effect:3.5.7",
     mvn"co.fs2::fs2-io:3.11.0",
@@ -89,10 +104,6 @@ object cli extends CommonScalaModule with NativeImageModule {
   }
 
   override def resources = super.resources() ++ Seq(bundledJreJar())
-
-  def cellarVersion: T[String] = Task.Input {
-    sys.env.getOrElse("CELLAR_VERSION", "0.1.0-SNAPSHOT").stripPrefix("v")
-  }
 
   def generatedSources = Task {
     val dir = Task.dest

--- a/build.mill
+++ b/build.mill
@@ -19,17 +19,19 @@ def cellarVersion: T[String] = Task.Input {
   sys.env.getOrElse("CELLAR_VERSION", "0.1.0-SNAPSHOT").stripPrefix("v")
 }
 
+def cellarPom(desc: String) = PomSettings(
+  description    = desc,
+  organization   = "org.virtuslab",
+  url            = "https://github.com/VirtusLab/cellar",
+  licenses       = Seq(License.`MPL-2.0`),
+  versionControl = VersionControl.github("VirtusLab", "cellar"),
+  developers     = Seq(Developer("rochala", "Jakub Rochala", "https://github.com/rochala"))
+)
+
 object lib extends CommonScalaModule with SonatypeCentralPublishModule {
   def publishVersion = cellarVersion()
-  def artifactName = "cellar-lib"
-  def pomSettings = PomSettings(
-    description    = "Programmatic access to JVM dependency APIs (Scala 3, Scala 2, Java)",
-    organization   = "org.virtuslab",
-    url            = "https://github.com/VirtusLab/cellar",
-    licenses       = Seq(License.`MPL-2.0`),
-    versionControl = VersionControl.github("VirtusLab", "cellar"),
-    developers     = Seq(Developer("rochala", "Jakub Rochala", "https://github.com/rochala"))
-  )
+  def artifactName   = "cellar-lib"
+  def pomSettings    = cellarPom("Programmatic access to JVM dependency APIs (Scala 3, Scala 2, Java)")
 
   def mvnDeps = Seq(
     mvn"org.typelevel::cats-effect:3.5.7",
@@ -69,10 +71,16 @@ object lib extends CommonScalaModule with SonatypeCentralPublishModule {
   }
 }
 
-object cli extends CommonScalaModule with NativeImageModule {
-  def moduleDeps = Seq(lib)
-  def mainClass = Some("cellar.cli.CellarApp")
+object cli extends CommonScalaModule with NativeImageModule with SonatypeCentralPublishModule {
+  def moduleDeps  = Seq(lib)
+  def mainClass   = Some("cellar.cli.CellarApp")
 
+  def publishVersion = cellarVersion()
+  def artifactName   = "cellar-cli"
+  def pomSettings    = cellarPom("Cellar command-line interface — JVM dependency API explorer")
+
+  // Only consumed in native-image mode (JRT filesystem is unreliable there —
+  // graal#10013), so kept off `resources` to avoid bloating the published lib JAR.
   def bundledJreJar: T[PathRef] = Task {
     import java.net.URI
     import java.nio.file.{Files, FileSystems}
@@ -103,7 +111,9 @@ object cli extends CommonScalaModule with NativeImageModule {
     PathRef(Task.dest)
   }
 
-  override def resources = super.resources() ++ Seq(bundledJreJar())
+  override def nativeImageClasspath = Task {
+    super.nativeImageClasspath() ++ Seq(bundledJreJar())
+  }
 
   def generatedSources = Task {
     val dir = Task.dest


### PR DESCRIPTION
## Summary

Add Sonatype Central publishing for the `lib` module as `org.virtuslab:cellar-lib_3` so the version is discoverable via `maven-metadata.xml`. This is the prerequisite for registering cellar in [coursier/apps](https://github.com/coursier/apps) — `cs install cellar` resolves the latest version from Maven Central, then downloads the matching native binary from the GitHub Release for this repo (same pattern as scala-cli).

The library is also independently usable as a Scala 3 dependency.

## Changes

- **`build.mill`** — `lib` extends `SonatypeCentralPublishModule` with full `PomSettings` (org.virtuslab, MPL-2.0, GitHub URL, developer info). `cellarVersion` hoisted to top-level so `lib.publishVersion` and `cli.generatedSources` share one source of truth.
- **`.github/workflows/release.yml`** — new `publish-maven` job runs `./mill lib.publishSonatypeCentral` in parallel with `build` and `jar`. The `release` job now also depends on it, so a failed Sonatype upload blocks the GitHub Release.
- **`RELEASING.md`** — documents the Maven coordinate, required GitHub secrets table, and the cosign-vs-PGP separation (PGP signs `.asc` for Maven artifacts; cosign keyless continues to sign `checksums.txt` for Release assets).

## Required setup before first release

This PR adds the publishing pipeline but does **not** include the external setup:

- [ ] Sonatype Central account with `org.virtuslab` namespace verified
- [ ] PGP signing key generated, public part uploaded to a keyserver
- [ ] Four GitHub repository secrets added: `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `PGP_SECRET` (base64'd private key), `PGP_PASSPHRASE`

After the first successful publish, a follow-up PR to `coursier/apps` will register the descriptor at `apps/resources/cellar.json`.

## Test plan

- [x] `./mill show lib.pom` renders a valid POM with `groupId=org.virtuslab`, `artifactId=cellar-lib_3`, MPL-2.0 license, SCM, dev info, and all dependencies correctly Scala-suffixed
- [x] `./mill resolve lib.publishSonatypeCentral` confirms the task is wired up
- [ ] Cut a `0.0.1-rc1` release once secrets are configured and confirm the artifact appears at `https://repo1.maven.org/maven2/org/virtuslab/cellar-lib_3/0.0.1-rc1/`
- [ ] After publish, `cs resolve org.virtuslab::cellar-lib:latest.release -V` should resolve to the new version