### PR TITLE
Use + separator between Mill tasks in publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           distribution: 'temurin'
 
       - name: Publish to Maven Central
-        run: ./mill lib.publishSonatypeCentral cli.publishSonatypeCentral
+        run: ./mill lib.publishSonatypeCentral + cli.publishSonatypeCentral
         env:
           CELLAR_VERSION: v${{ inputs.version }}
           MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
## Summary

Releases were failing at the publish step with:

```
Error:  Unknown argument: "cli.publishSonatypeCentral"
Expected Signature: publishSonatypeCentral
  --username <str>
  --password <str>
  ...
```

`./mill lib.publishSonatypeCentral cli.publishSonatypeCentral` was being parsed as task=`lib.publishSonatypeCentral` with positional arg `cli.publishSonatypeCentral`. `publishSonatypeCentral` is a `Task.Command` that accepts only named arguments, so it rejected the positional input.

## Fix

One character — insert `+` between the two task names. Mill 1.x's official multi-task separator (per `./mill --help`):

```
Usage: mill [options] task [task-options] [+ task ...]
```

## Test plan

Verified locally with `./mill lib.publishLocal + cli.publishLocal`:

```
178] lib.publishLocal
178] Publishing Artifact(org.virtuslab,cellar-lib_3,0.1.0-SNAPSHOT) ...
180] cli.publishLocal
180] Publishing Artifact(org.virtuslab,cellar-cli_3,0.1.0-SNAPSHOT) ...
SUCCESS] ./mill lib.publishLocal + cli.publishLocal
```

Both modules publish in a single Mill invocation.