### PR TITLE
Gate Maven publish on native-binary and JAR builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,10 @@ jobs:
   publish-maven:
     name: Publish lib + cli to Maven Central
     runs-on: ubuntu-latest
+    # Gate the upload on native-binary + JAR builds: a Sonatype release is
+    # immutable, so we must not publish a version whose GitHub Release assets
+    # (referenced by the coursier descriptor's prebuiltBinaries) won't exist.
+    needs: [build, jar]
     # No-op unless `maven-central` env is configured in repo settings with the
     # SONATYPE_* / PGP_* secrets moved onto it (see RELEASING.md).
     environment: maven-central

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,7 +23,7 @@ This document describes how to cut a release, what artifacts are produced, and h
    - Creates and pushes a `v<version>` git tag.
    - Publishes a GitHub Release with all artifacts attached.
 
-The Maven publish runs in parallel with the binary builds and blocks the GitHub Release; if Sonatype rejects the upload (e.g. duplicate version, namespace mismatch, signature failure), no GitHub Release is created and no tag is pushed.
+The Maven publish waits for the native-binary and JAR builds to succeed before uploading — a Sonatype release is immutable, so we must not publish a version whose corresponding GitHub Release assets (referenced by the coursier app descriptor) failed to build. If Sonatype then rejects the upload (e.g. duplicate version, namespace mismatch, signature failure), no GitHub Release is created and no tag is pushed.
 
 No container images are built or published by this release flow.
 


### PR DESCRIPTION
## Summary
- `publish-maven` now declares `needs: [build, jar]` so it waits for all native-image and assembly-JAR builds to succeed before uploading to Sonatype Central.
- Sonatype releases are immutable: if we publish version `V` to Maven Central but the GitHub Release binaries for `V` then fail to build, the coursier app descriptor would resolve `latest.release` to `V` and 404 on the prebuilt download. Gating the upload on the binary jobs prevents that drift.
- `RELEASING.md` updated to describe the new ordering.

## Test plan
- [ ] Trigger a dry-run release (e.g. against a `0.1.0-rc` version) and confirm `publish-maven` doesn't start until all four `build` matrix entries and `jar` finish successfully.
- [ ] Force a `build` failure on one platform and confirm `publish-maven` is skipped, no Sonatype upload occurs, and no GitHub Release is cut.