### PR TITLE
Show runtime and platform in --version output

### DIFF
--- a/cli/src/cellar/cli/CellarApp.scala
+++ b/cli/src/cellar/cli/CellarApp.scala
@@ -12,11 +12,27 @@ import fs2.io.file.Path
 
 import scala.concurrent.duration.Duration
 
+private def runtimeLabel: String =
+  if System.getProperty("org.graalvm.nativeimage.imagecode") == "runtime" then "native-image"
+  else s"JVM ${System.getProperty("java.version")}"
+
+private def platformLabel: String =
+  val os = System.getProperty("os.name").toLowerCase match
+    case n if n.contains("mac")   => "macos"
+    case n if n.contains("linux") => "linux"
+    case n if n.contains("win")   => "windows"
+    case other                    => other
+  val arch = System.getProperty("os.arch") match
+    case "aarch64"          => "arm64"
+    case "x86_64" | "amd64" => "x86_64"
+    case other              => other
+  s"$os-$arch"
+
 object CellarApp
     extends CommandIOApp(
       name = "cellar",
       header = "Inspect Maven-published JVM dependency APIs",
-      version = BuildInfo.version
+      version = s"${BuildInfo.version} ($runtimeLabel, $platformLabel)"
     ):
 
   override def runtimeConfig: IORuntimeConfig =


### PR DESCRIPTION
## Summary
- Append \`(native-image, <os>-<arch>)\` or \`(JVM <java.version>, <os>-<arch>)\` to \`cellar --version\` so users can tell whether they are running the GraalVM native image or a JVM bootstrap, and on which platform.
- Native image is detected via the \`org.graalvm.nativeimage.imagecode=runtime\` system property.
- The platform label mirrors the prebuilt-binary keys in the Coursier launcher's \`info.json\` (e.g. \`macos-arm64\`, \`linux-x86_64\`), making bug reports easy to map back to a published tarball.

Motivation: when the GitHub release for a version is missing, Coursier silently falls back to a JVM bootstrap launcher built from the Maven JAR. Today this is invisible — the JVM bootstrap and the native image both report just the version number. With this change the difference is obvious.

## Test plan
- [x] \`./mill cli.compile\` passes
- [x] \`java -jar out/cli/assembly.dest/out.jar --version\` prints \`0.1.0-SNAPSHOT (JVM 21.0.1, macos-arm64)\` locally
- [ ] After release, verify a native-image install prints \`(native-image, <os>-<arch>)\`