### PR TITLE
Tighten cellar plugin docs and Maven coordinate clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,11 +263,11 @@ Install cellar as a Claude Code plugin for auto-updates:
 /plugin install cellar@virtuslab-cellar
 ```
 
-Claude will automatically have access to the `/cellar:cellar` skill and know when to use it.
+Claude will have access to the `/cellar:cellar` skill, which loads on demand for JVM library API questions. For more consistent triggering, also add the snippet below to your project's `CLAUDE.md`.
 
 ### Manual setup
 
-Alternatively, add the following to your project's `CLAUDE.md`:
+Add the following to your project's `CLAUDE.md`:
 
 ````markdown
 ## Cellar

--- a/skills/cellar/SKILL.md
+++ b/skills/cellar/SKILL.md
@@ -34,8 +34,8 @@ Query any published artifact by explicit coordinate (`group:artifact:version`):
     cellar deps <coordinate>                     # dependency tree
 
 - Coordinates must be explicit: `group:artifact_3:version` (no `::` shorthand)
-- For sbt plugins, use the full Scala and sbt suffix: `group:artifact_2.12_1.0:version` (e.g. `org.scala-native:sbt-scala-native_2.12_1.0:latest`)
-- For compiler plugins and other artifacts with full Scala version suffixes, use the full version: `group:artifact_3.3.8:version`
+- For sbt plugins, use the full Scala and sbt-binary-version suffix: `group:artifact_2.12_1.0:version` (the `_1.0` is sbt's binary version, e.g. `org.scala-native:sbt-scala-native_2.12_1.0:latest`)
+- For compiler plugins (published per Scala patch version) and similar artifacts, use the full Scala version in the suffix: `group:artifact_3.3.8:version`
 - Use `latest` as the version to resolve the most recent release
 - `-r`, `--repository <url>`: extra Maven repository (repeatable)
 


### PR DESCRIPTION
## TL;DR

Two tiny doc cleanups:

- **README**: remove the misleading *"Claude will know when to use it"* claim from the plugin install section, and point users to the manual `CLAUDE.md` snippet for higher trigger reliability.
- **SKILL.md**: clarify the sbt-plugin and compiler-plugin coordinate notes (the `_1.0` is sbt's binary version; compiler plugins are published per Scala patch version).

8 lines changed total. The PR is small but the *reason* it's this small is interesting — it's the result of a deeper investigation that landed at "the existing setup is already working." Writeup below for posterity / future you.

## How this PR shrunk

This branch was originally an effort to ship a plugin `SessionStart` hook that would inject a cellar reminder into every session. The motivation: we'd run `skill-creator`'s `run_loop.py` against the cellar skill and gotten **0% trigger recall** across 5 description variants on Sonnet 4.6 and 2 on Opus 4.7 — looked like the skill description was completely failing to make the model reach for cellar.

That finding turned out to be a **measurement bug** in the eval harness.

### The bug

`run_loop.py` registers a synthetic skill in `.claude/commands/` and detects whether it triggers by watching for `Skill` and `Read` tool invocations of that synthetic skill name. The cellar skill description tells the model to *"use the cellar CLI from the terminal"* — so a model that **does** follow the description reaches for the **Bash** tool (`cellar get-external …`), not the Skill tool. **Bash invocations were not being counted as triggers.**

### Re-measurement with proper detection

We wrote a Bash-aware detector (counts `Bash` tool_use events with `cellar` in the command, plus assistant-text mentions of cellar commands as a fallback), and re-ran the same 20-query trigger set on Sonnet 4.6 with 3 runs per query.

| Setup | cwd | Project CLAUDE.md | Always-loaded snippet | Recall | Precision | Accuracy |
|---|---|---|---|---|---|---|
| Original `run_loop.py` (buggy detector) | cellar repo | yes | no | 0% | 100% | 50% |
| `verify_baseline` (Bash-aware) | cellar repo | yes | no | **90%** (9/10) | 100% | 95% |
| `verify_clean` (Bash-aware) | /tmp clean | no | no | **90%** (9/10) | 90% | 90% |
| `verify_hook` (proxy via `--append-system-prompt`) | cellar repo | yes | yes | 100% (10/10) | 90.9% | 95% |

Findings:
- **Skill description alone gets 90% recall** even from a clean directory with no project CLAUDE.md.
- The hook proxy added ~10pp on top — real but modest.
- The actual `SessionStart` hook can't be measured this way because it doesn't fire on `claude -p`. Only interactive smoke-testing would tell us the real number.

### Decision

Shipping a hook to capture an unmeasured ~10pp improvement on top of something already working at 90% is overengineering. We dropped the hook. The README still points to the manual `CLAUDE.md` snippet for users who want higher reliability — it's the same always-loaded mechanism a hook would provide, just with one extra step.

### What didn't change

The cellar skill itself wasn't modified beyond doc clarifications — earlier commits had tightened the description with pushier wording, but we never validated that helped triggering, so those got reverted before the final squash.

## Reusable artifacts

`skills/cellar-workspace/` (workspace, not committed) contains:

- `trigger-eval-set.json` — 20-query trigger set (10 should-trigger, 10 should-not-trigger near-misses), ready to re-run on future model releases
- `verify_baseline.py` / `verify_clean.py` / `verify_hook.py` — corrected (Bash-aware) detection scripts
- `iteration-1/` — body comparison outputs
- `trigger-loop/2026-05-08_000313/` — the original (buggy-detector) trigger loop result for posterity

If a future Claude model gets noticeably better or worse at "I might be wrong about this library" reasoning, re-running the eval is a 7-minute exercise.

## Files changed (only 8 lines)

- `README.md` — 4-line edit to the plugin install section (replaces a misleading sentence, adds a pointer to the manual snippet)
- `skills/cellar/SKILL.md` — 4-line edit clarifying sbt-plugin and compiler-plugin coordinate suffixes

## Test plan

- [ ] Verify the README still reads cleanly end-to-end
- [ ] Verify the sbt-plugin and compiler-plugin coordinate examples in SKILL.md are still accurate
