### PR TITLE
README: document Coursier as the recommended install method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ Cellar gives agents — and humans — a single shell command that returns exact
 
 ## Installation
 
+### Coursier (recommended)
+
+If you have [Coursier](https://get-coursier.io/) installed:
+
+```sh
+cs install --contrib cellar
+```
+
+This pulls the GraalVM native binary for your platform from the latest GitHub Release. Update with `cs update cellar`.
+
 ### Nix
 
 Run without installing:


### PR DESCRIPTION
## Summary

- Add a "Coursier (recommended)" subsection at the top of `## Installation` with the `cs install --contrib cellar` command.
- Keep Nix and Manual as the existing alternatives.

## Why

Cellar already has an entry in coursier's contrib channel: [`apps-contrib/resources/cellar.json`](https://github.com/coursier/apps/blob/main/apps-contrib/resources/cellar.json). The descriptor pulls the GraalVM native binary from the matching GitHub Release, so users get the same prebuilt artifact as the manual tarball install — just with one command (`cs install --contrib cellar`) and automatic updates via `cs update cellar`.

`RELEASING.md` already documented that the coursier descriptor was the resolution path; this PR just makes it user-facing.

Verified locally: `cs install --contrib cellar` resolved against `org.virtuslab:cellar-cli_3` via the contrib channel and wrote a working `cellar` binary.

## Test plan

- [ ] Verify the README still reads cleanly end-to-end after the install section reordering
- [ ] (Optional, on a clean machine) `cs install --contrib cellar` and confirm the resulting binary runs