### PR TITLE
Track nixpkgs-unstable instead of nixos-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1775036866,
-        "narHash": "sha256-ZojAnPuCdy657PbTq5V0Y+AHKhZAIwSIT2cb8UgAz/U=",
+        "lastModified": 1778672786,
+        "narHash": "sha256-Blg88K1jwG+P0Mr27+rKMFCufdrWkV3wWh9AdYtz0FQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6201e203d09599479a3b3450ed24fa81537ebc4e",
+        "rev": "eef00dfd8a712b34af845f9350bac681b1228bd1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Look up the public API of any JVM dependency from the terminal";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   outputs = { self, nixpkgs }:
     let


### PR DESCRIPTION
## Summary
- Switch the `nixpkgs` flake input from `nixos-unstable` to `nixpkgs-unstable`.
- This flake only packages the `cellar` binary (no NixOS modules / VM tests), so the NixOS release-blocking jobset that `nixos-unstable` waits on is unused latency. `nixpkgs-unstable` advances on the smaller package jobset and gives fresher package versions.
- `flake.lock` updated to the matching `nixpkgs-unstable` revision.

## Test plan
- [ ] `nix flake check`
- [ ] `nix build .#default` on at least one supported system

🤖 Generated with [Claude Code](https://claude.com/claude-code)