### PR TITLE
Resolve Scala 3 top-level defs, types, and objects

### DIFF
--- a/fixtureScala3/src/myapp/Hello.scala
+++ b/fixtureScala3/src/myapp/Hello.scala
@@ -1,0 +1,9 @@
+package myapp
+
+@main def hello =
+  println(42)
+
+opaque type Hello = Int
+
+object Hello:
+  def fromInt(a: Int): Hello = a

--- a/lib/src/cellar/SymbolResolver.scala
+++ b/lib/src/cellar/SymbolResolver.scala
@@ -21,7 +21,11 @@ object SymbolResolver:
       case None         => IO.blocking(tryNestedLookup(fqn)).map(_.getOrElse(LookupResult.NotFound))
     }
 
-  /** Try to resolve as a top-level class, module, term, type, or package. */
+  /**
+   * Try to resolve as a top-level class, module, term, type, package, or
+   * Scala-3 top-level decl (which lives in a synthetic `<filename>$package$`
+   * module class). All public hits with the same FQN are returned.
+   */
   private def tryTopLevel(fqn: String)(using ctx: Context): Option[LookupResult] =
     var caught: Option[Throwable] = None
     // ClassCastException is a known tastyquery quirk: thrown (instead of MemberNotFoundException)
@@ -42,12 +46,17 @@ object SymbolResolver:
       t(ctx.findStaticModuleClass(stripped)).map(s => LookupResult.Found(List(s)))
         .orElse(caught.map(LookupResult.LookupFailed(_)))
     else
-      t(ctx.findStaticClass(fqn)).map(s => LookupResult.Found(List(s)))
-        .orElse(t(ctx.findStaticModuleClass(fqn)).map(s => LookupResult.Found(List(s))))
-        .orElse(tryOrNone(ctx.findStaticTerm(fqn)).map(s => LookupResult.Found(List(s))))
-        .orElse(tryOrNone(ctx.findStaticType(fqn)).map(s => LookupResult.Found(List(s))))
-        .orElse(tryOrNone(ctx.findPackage(fqn)).map(_ => LookupResult.IsPackage))
-        .orElse(caught.map(LookupResult.LookupFailed(_)))
+      val direct = List(
+        t(ctx.findStaticClass(fqn)),
+        t(ctx.findStaticModuleClass(fqn)),
+        tryOrNone(ctx.findStaticTerm(fqn)),
+        tryOrNone(ctx.findStaticType(fqn))
+      ).flatten
+      val all = (direct ++ packageWrapperMembers(fqn)).distinct
+      if all.nonEmpty then Some(LookupResult.Found(all))
+      else
+        tryOrNone(ctx.findPackage(fqn)).map(_ => LookupResult.IsPackage)
+          .orElse(caught.map(LookupResult.LookupFailed(_)))
 
   /**
    * Multi-segment nested member walk.
@@ -191,10 +200,37 @@ object SymbolResolver:
           case scala.util.control.NonFatal(e) =>
             if firstError.isEmpty then firstError = Some(e)
             None
-      val found = t(ctx.findStaticClass(prefix)).orElse(t(ctx.findStaticModuleClass(prefix)))
+      val found = t(ctx.findStaticClass(prefix))
+        .orElse(t(ctx.findStaticModuleClass(prefix)))
+        .orElse(packageWrapperClass(prefix))
       if found.isDefined then best = Some((found.get, i + 1))
       i += 1
     (best, firstError)
+
+  /**
+   * Scala 3 top-level defs/types/objects in `pkg` live inside a synthetic
+   * `<filename>$package$` module class. Walks every such wrapper in `pkg` and
+   * applies `f` with the member name to be looked up.
+   */
+  private def withPackageWrappers[A](fqn: String)(f: (ClassSymbol, String) => IterableOnce[A])(using ctx: Context): List[A] =
+    val idx = fqn.lastIndexOf('.')
+    if idx < 0 then return Nil
+    val name = fqn.substring(idx + 1)
+    tryOrNone(ctx.findPackage(fqn.substring(0, idx))).toList.flatMap { pkg =>
+      tryOrNone(pkg.declarations).getOrElse(Nil).flatMap {
+        case c: ClassSymbol if c.isModuleClass && c.name.toString.endsWith("$package$") =>
+          f(c, name).iterator.toList
+        case _ => Nil
+      }
+    }
+
+  private def packageWrapperMembers(fqn: String)(using ctx: Context): List[Symbol] =
+    withPackageWrappers[Symbol](fqn) { (w, name) =>
+      w.getAllOverloadedDecls(termName(name)) ++ w.getDecl(typeName(name))
+    }.filter(PublicApiFilter.isPublic)
+
+  private def packageWrapperClass(fqn: String)(using ctx: Context): Option[ClassSymbol] =
+    withPackageWrappers[ClassSymbol](fqn)((w, name) => directClassMember(w, name)).headOption
 
   private[cellar] val universalBaseClasses = Set("scala.Any", "scala.AnyRef", "java.lang.Object")
 

--- a/lib/test/src/cellar/SymbolResolverTest.scala
+++ b/lib/test/src/cellar/SymbolResolverTest.scala
@@ -190,3 +190,46 @@ class SymbolResolverTest extends CatsEffectSuite:
         case other => fail(s"Expected PartialMatch, got $other")
       }
     }
+
+  // Scala 3 top-level defs/types/objects live in a synthetic `<filename>$package$`
+  // wrapper class. SymbolResolver fans out into those wrappers so users can refer
+  // to top-level symbols by their natural FQN.
+  // Fixture: fixtureScala3/src/myapp/Hello.scala
+  //   package myapp
+  //   @main def hello = println(42)
+  //   opaque type Hello = Int
+  //   object Hello:
+  //     def fromInt(a: Int): Hello = a
+
+  test("top-level @main def myapp.hello resolves to both the def and the synthetic wrapper class"):
+    withCtx { ctx =>
+      given Context = ctx
+      SymbolResolver.resolve("myapp.hello").map {
+        case LookupResult.Found(syms) =>
+          assert(
+            syms.exists(s => s.isInstanceOf[tastyquery.Symbols.TermSymbol] && s.name.toString == "hello"),
+            s"Expected to find the top-level def, got $syms"
+          )
+        case other => fail(s"Expected Found, got $other")
+      }
+    }
+
+  test("top-level opaque type myapp.Hello resolves"):
+    withCtx { ctx =>
+      given Context = ctx
+      SymbolResolver.resolve("myapp.Hello").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.exists(_.name.toString == "Hello"), s"Expected to find Hello, got $syms")
+        case other => fail(s"Expected Found, got $other")
+      }
+    }
+
+  test("top-level companion member myapp.Hello.fromInt resolves"):
+    withCtx { ctx =>
+      given Context = ctx
+      SymbolResolver.resolve("myapp.Hello.fromInt").map {
+        case LookupResult.Found(syms) =>
+          assert(syms.exists(_.name.toString == "fromInt"), s"Expected to find fromInt, got $syms")
+        case other => fail(s"Expected Found, got $other")
+      }
+    }


### PR DESCRIPTION
## Summary

Scala 3 compiles top-level declarations (defs, opaque types, objects) inside `pkg` into a synthetic `<filename>$package$` module class on the JVM. Before this change, `SymbolResolver` only searched direct package members, so the natural FQN for any top-level decl was unfindable:

| FQN | Before | After |
|---|---|---|
| `myapp.helloDef` | `NotFound` (or worse: returns an unrelated `@main`-wrapper class with the same name) | `Found(def hello)` (plus the wrapper, when one exists) |
| `myapp.MyOpaqueType` | `NotFound` | `Found(opaque alias)` |
| `myapp.MyObject.member` | `NotFound` | `Found(member)` |

`SymbolResolver` now fans out into every `<filename>$package$` module class in the target package and merges the hits with the existing static lookups. Multiple hits across namespaces (term + type) are returned as an overload-style list — matching how cellar already handles overloaded methods.

The fix touches two paths:
- `tryTopLevel(fqn)` — single-segment resolution
- `findTopLevelRoot(segments)` — establishing the root for nested walks like `pkg.Obj.member`

A new fixture file `fixtureScala3/src/myapp/Hello.scala` exercises all three shapes (top-level `@main def`, top-level opaque type, top-level object with a method), and three new tests in `SymbolResolverTest` pin the behavior.

## Test plan

- [x] `./mill lib.test.testOnly cellar.SymbolResolverTest` — 19/19 pass (16 existing + 3 new)
- [x] `./mill lib.test` — full suite green, no regressions
- [x] End-to-end CLI check: `cellar get-external -r file://~/.m2/repository cellar.test:cellar-fixture-scala3_3:0.1.0-SNAPSHOT myapp.{hello,Hello,Hello.fromInt}` all return the user-written symbols