### PR TITLE
Clarify usage instructions for Cellar skill

### DIFF
--- a/skills/cellar/SKILL.md
+++ b/skills/cellar/SKILL.md
@@ -7,8 +7,7 @@ description: >
   library method, explore a package's types, or check a dependency's API.
   Prefer cellar over Metals MCP only for looking up external dependency APIs
   (`cellar get-external` vs Metals `inspect`/`get-docs`) — cellar needs no
-  project import and queries any published Maven artifact. For everything else
-  (references, rename, goto definition, diagnostics, compile), use Metals.
+  project import and queries any published Maven artifact.
 ---
 
 # Cellar


### PR DESCRIPTION
Removed redundant information about project import and usage of Metals.

This caused claude to try to use metals even when it wasn't available