### PR TITLE
Match FQN-style queries in search (#83)

### DIFF
--- a/lib/src/cellar/handlers/SearchHandler.scala
+++ b/lib/src/cellar/handlers/SearchHandler.scala
@@ -35,13 +35,22 @@ object SearchHandler:
       jreClasspath: tastyquery.Classpaths.Classpath
   )(using tastyquery.Contexts.Context, Console[IO]): IO[ExitCode] =
     val lowerQuery = query.toLowerCase
+    // A dotted query (e.g. `cats.FlatMap`) is FQN-style: match it against the
+    // symbol's full name rather than its simple name, otherwise it can never
+    // match and search silently returns nothing.
+    val isFqnQuery = lowerQuery.contains('.')
+    def matchTarget(sym: tastyquery.Symbols.TermOrTypeSymbol): String =
+      if isFqnQuery then
+        try sym.displayFullName
+        catch case _: Exception => sym.name.toString
+      else sym.name.toString
     val matchingStream = AllSymbolsStream
       .stream(classpath, jreClasspath)
-      .filter(sym => sym.name.toString.toLowerCase.contains(lowerQuery))
+      .filter(sym => matchTarget(sym).toLowerCase.contains(lowerQuery))
     // Rank exact-name matches first, then prefix matches, then by length — so
     // `Monad` beats `Bimonad`/`MonadError` regardless of declaration order.
     matchingStream.compile.toList.flatMap { allMatches =>
-      val sorted  = allMatches.sortBy(sym => rankKey(lowerQuery, sym.name.toString))
+      val sorted  = allMatches.sortBy(sym => rankKey(lowerQuery, matchTarget(sym)))
       val limited = sorted.take(limit)
       val note    = if sorted.length > limit then
         Console[IO].errorln(s"Note: results truncated at $limit. Use --limit to increase.")

--- a/lib/test/src/cellar/SearchHandlerTest.scala
+++ b/lib/test/src/cellar/SearchHandlerTest.scala
@@ -38,3 +38,8 @@ class SearchHandlerTest extends FunSuite:
   test("rankKey: companion module ($-suffixed) sorts right after exact match"):
     val sorted = sort("Monad", List("MonadError", "Monad$", "Monad", "Bimonad"))
     assertEquals(sorted.take(2), List("Monad", "Monad$"))
+
+  test("rankKey: FQN-style query ranks the exact full-name match first"):
+    // FQN queries are matched/ranked against the symbol's full name.
+    val sorted = sort("cats.FlatMap", List("cats.syntax.FlatMapOps", "cats.FlatMap", "cats.FlatMapArityFunctions"))
+    assertEquals(sorted.head, "cats.FlatMap")


### PR DESCRIPTION
## Problem

Closes #83.

`search` / `search-external` filtered candidates only against the symbol's **simple** name (`sym.name.toString`). A dotted, FQN-style query such as `cats.FlatMap` could therefore never match — and it failed silently with exit code 0 and no output, which reads as "no such symbol" rather than a bug. (`get`/`list` take FQNs by design and were unaffected; this only ever hit `search`.)

```sh
cellar search-external org.typelevel:cats-core_3:2.12.0 FlatMap       # works
cellar search-external org.typelevel:cats-core_3:2.12.0 cats.FlatMap  # before: empty
```

## Fix

In `SearchHandler.runCore`, detect a dotted query and match/rank it against the symbol's `displayFullName` (with a try/catch fallback to the simple name, since `displayFullName` can throw on some symbols). Simple-name search is unchanged.

## Verification

End-to-end against `org.typelevel:cats-core_3:2.12.0`:

- `cats.FlatMap` now returns `cats.FlatMap` and friends
- nested `syntax.FlatMap` returns `cats.syntax.FlatMap*`
- plain `FlatMap` unchanged

Added a `rankKey` test covering FQN exact-match ordering; full `lib.test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)