### PR TITLE
Add rolling 30-day active-installs metric

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -47,6 +47,28 @@ services:
     networks:
       - cellar-network
 
+  # Receives the install-counter batch job's single gauge and holds it for
+  # Prometheus to scrape. Standard Prometheus pattern for a periodic job that
+  # has no long-lived HTTP surface of its own.
+  pushgateway:
+    image: prom/pushgateway:v1.11.0
+    restart: unless-stopped
+    networks:
+      - cellar-network
+
+  # Daily job: counts distinct installation.id over the trailing 30 days from
+  # Tempo and publishes cellar_active_installs_30d to Pushgateway. Aggregate
+  # only — no installation.id reaches Prometheus (see count.sh).
+  install-counter:
+    image: alpine:3.20
+    entrypoint: ["/bin/sh", "/count.sh"]
+    volumes:
+      - ./install-counter/count.sh:/count.sh:ro
+    depends_on: [tempo, pushgateway]
+    restart: unless-stopped
+    networks:
+      - cellar-network
+
   grafana:
     image: grafana/grafana:13.0.1
     volumes:

--- a/deploy/install-counter/count.sh
+++ b/deploy/install-counter/count.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+# Rolling 30-day active-installs counter.
+#
+# Once a day: ask Tempo for the distinct values of the span.installation.id
+# attribute over the trailing 30 days, count them, and publish the count to
+# Pushgateway as cellar_active_installs_30d. Prometheus scrapes it from there
+# and retains it long-term. Only the aggregate count is stored — no
+# installation.id ever reaches Prometheus, preserving the "no pseudonymous
+# identifier in the metrics store" invariant.
+#
+# The count is approximate by design: it is a rolling MAU-style figure bounded
+# by trace retention (30d), sampling, and Tempo's max_bytes_per_tag_values_query
+# response cap. When the response nears that cap the count would silently
+# under-report, so we warn rather than publish a wrong number quietly.
+set -eu
+
+TEMPO_URL=http://tempo:3200
+PUSHGATEWAY_URL=http://pushgateway:9091
+WINDOW_SECONDS=2592000   # 30 days
+INTERVAL_SECONDS=86400   # once a day, after a successful push
+RETRY_SECONDS=60         # after a failure (e.g. Tempo not yet ready)
+# ~90% of Tempo's default 5 MB max_bytes_per_tag_values_query. Past this the
+# tag-values response may be truncated and the count under-reports.
+CAP_WARN_BYTES=4718592
+
+apk add --no-cache curl jq >/dev/null
+
+while true; do
+  end="$(date +%s)"
+  start="$((end - WINDOW_SECONDS))"
+  sleep_for="$RETRY_SECONDS"
+
+  if body="$(curl -sf "${TEMPO_URL}/api/v2/search/tag/span.installation.id/values?start=${start}&end=${end}")"; then
+    count="$(printf '%s' "$body" | jq '.tagValues | length')"
+    bytes=${#body}
+
+    if [ "$bytes" -ge "$CAP_WARN_BYTES" ]; then
+      echo "WARN: tag-values response is ${bytes} bytes, near max_bytes_per_tag_values_query cap; count ${count} may be truncated" >&2
+    fi
+
+    if printf 'cellar_active_installs_30d %s\n' "$count" \
+        | curl -sf --data-binary @- "${PUSHGATEWAY_URL}/metrics/job/install_counter"; then
+      echo "pushed cellar_active_installs_30d=${count}"
+      sleep_for="$INTERVAL_SECONDS"
+    else
+      echo "ERROR: push to Pushgateway failed" >&2
+    fi
+  else
+    echo "ERROR: Tempo tag-values query failed" >&2
+  fi
+
+  sleep "$sleep_for"
+done

--- a/deploy/prometheus/prometheus.yml
+++ b/deploy/prometheus/prometheus.yml
@@ -3,5 +3,15 @@ global:
   external_labels:
     source: cellar
 
-# No scrape jobs: Tempo's metrics_generator pushes to /api/v1/write
+# Tempo's metrics_generator pushes RED/duration series to /api/v1/write
 # (the remote-write receiver is enabled via the --web flag).
+#
+# The one scrape job is the install-counter batch job's Pushgateway: it
+# publishes cellar_active_installs_30d (a rolling 30-day distinct count of
+# installation.id, aggregate only — no pseudonymous label). honor_labels
+# keeps the job/instance the counter set instead of overwriting them.
+scrape_configs:
+  - job_name: pushgateway
+    honor_labels: true
+    static_configs:
+      - targets: ["pushgateway:9091"]

--- a/deploy/tempo-config.yml
+++ b/deploy/tempo-config.yml
@@ -10,6 +10,14 @@ distributor:
         http:
           endpoint: 0.0.0.0:4318
 
+# The install-counter batch job queries a 30-day tag-values window for the
+# rolling active-installs count; the default 168h search cap would reject it.
+# Raised to cover full trace retention (720h). The search API (port 3200) is
+# not publicly exposed, so this only widens the admin's own Grafana searches.
+query_frontend:
+  search:
+    max_duration: 744h
+
 storage:
   trace:
     backend: local


### PR DESCRIPTION
## What

Adds a persistent, privacy-preserving estimate of monthly-active installs to the `deploy/` telemetry stack.

A daily batch job (`install-counter`) queries Tempo for the distinct set of `span.installation.id` over the trailing 30 days, counts them, and publishes `cellar_active_installs_30d` to a Pushgateway that Prometheus scrapes. This gives a long-term MAU-style usage figure that survives Tempo's 30-day trace retention.

## Why this shape

`installation.id` is deliberately kept **out** of the Tempo→Prometheus span-metrics dimension allowlist (it's the privacy boundary), so the count cannot be derived from existing series. The Tempo-query + Pushgateway detour is a genuine necessity, not a reinvention.

The **privacy invariant holds**: only the aggregate count reaches Prometheus — never `installation.id` itself. So no `PRIVACY_POLICY.md`/allowlist changes are needed; the job only reads already-collected, already-disclosed data from Tempo within its existing 30-day window.

## Changes

- **`deploy/install-counter/count.sh`** (new) — the loop. Warns near Tempo's `max_bytes_per_tag_values_query` cap (so it never publishes a silently-truncated count), and retries quickly on failure so a cold-start race with Tempo doesn't leave the metric empty for a day.
- **`deploy/docker-compose.yml`** — `pushgateway` + `install-counter` services.
- **`deploy/prometheus/prometheus.yml`** — pushgateway scrape job (`honor_labels`).
- **`deploy/tempo-config.yml`** — raise `query_frontend.search.max_duration` to 744h so the 30-day tag-values query isn't rejected by the default 168h cap (search API isn't publicly exposed, so this only affects admin searches).

## Verification

Brought the full stack up locally and confirmed end-to-end: `install-counter` logs `pushed cellar_active_installs_30d=…`, and `cellar_active_installs_30d{job="install_counter"}` is queryable in Prometheus.

## Deploy note

The `tempo-config.yml` and `prometheus.yml` changes need a **container restart/recreate** to take effect — a mounted-config edit alone doesn't reload them.

## Possible follow-up

A freshness alert (`time() - push_time_seconds{job="install_counter"} > 172800`) so a dead counter doesn't leave Pushgateway serving a stale value indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)