### PR TITLE
Link Privacy Policy in telemetry consent flow

### DIFF
--- a/cli/src/cellar/cli/CellarApp.scala
+++ b/cli/src/cellar/cli/CellarApp.scala
@@ -79,7 +79,7 @@ object CellarApp extends ProfilingIOApp:
                |    { "label": "Disable",          "description": "Opt out for this project.",               "command": "cellar telemetry disable" },
                |    { "label": "Disable globally", "description": "Never ask again across any project.",     "command": "cellar telemetry disable --global" }
                |  ],
-               |  "details": "https://github.com/VirtusLab/cellar#telemetry"
+               |  "details": "Telemetry overview: https://github.com/VirtusLab/cellar#telemetry — Privacy Policy: https://github.com/VirtusLab/cellar/blob/main/PRIVACY_POLICY.md"
                |}""".stripMargin
           IO(System.err.println(json)) *>
             Files[IO].createDirectories(projectMarker.parent.get) *>

--- a/cli/src/cellar/cli/TelemetrySubcommand.scala
+++ b/cli/src/cellar/cli/TelemetrySubcommand.scala
@@ -22,7 +22,10 @@ object TelemetrySubcommand:
       Opts.unit.map { _ =>
         setEnabled(true) *> markAnswered *>
           InstallationId.ensure.flatMap(id =>
-            IO.println(s"Telemetry enabled. Installation ID: $id")
+            IO.println(
+              s"Telemetry enabled. Installation ID: $id\n" +
+                "Privacy Policy: https://github.com/VirtusLab/cellar/blob/main/PRIVACY_POLICY.md"
+            )
           ).as(ExitCode.Success)
       }
     }


### PR DESCRIPTION
## What

Surface the Privacy Policy directly at the two telemetry consent surfaces:

- **First-run opt-in prompt** (`CellarApp.scala`): the `AskUserQuestion` `details` field now includes a direct Privacy Policy link alongside the existing telemetry overview link (previously it only pointed at the README `#telemetry` anchor).
- **`cellar telemetry enable`** (`TelemetrySubcommand.scala`): now prints the Privacy Policy URL alongside the installation ID (previously it referenced the policy nowhere).

## Why

The Privacy Policy is the formal legal disclosure of what telemetry is collected. Consent should reference it directly at the moment it's given, rather than only via an indirect README hop.

Both links point at `https://github.com/VirtusLab/cellar/blob/main/PRIVACY_POLICY.md` — the same target README's relative `[Privacy Policy](PRIVACY_POLICY.md)` link resolves to on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)