### PR TITLE
Add on-demand rolling GitHub snapshot release

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,0 +1,122 @@
+name: Snapshot
+
+# On-demand development snapshot. Builds the native binaries + JAR from the
+# dispatched ref and publishes them to a single rolling `snapshot` prerelease
+# whose assets are overwritten each run. No Maven publish, no tag/flake mutation
+# of `main`. Asset names are version-less so download URLs stay stable.
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: linux-x86_64
+          - os: ubuntu-24.04-arm
+            target: linux-aarch64
+          - os: macos-latest
+            target: macos-arm64
+          - os: macOS-15-intel
+            target: macos-x86_64
+
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Static linking on Linux requires zlib headers
+      - name: Install native-image prerequisites (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install -y libz-dev
+
+      - name: Build native image
+        run: |
+          export CELLAR_VERSION="0.1.0-SNAPSHOT-$(git rev-parse --short HEAD)"
+          ./mill cli.nativeImage
+
+      - name: Package artifact
+        shell: bash
+        run: |
+          ARCHIVE="cellar-${{ matrix.target }}.tar.gz"
+          mkdir staging
+          cp out/cli/nativeImage.dest/native-executable staging/cellar
+          cp README.md staging/
+          tar -czf "${ARCHIVE}" -C staging .
+          echo "ARCHIVE=${ARCHIVE}" >> "$GITHUB_ENV"
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ARCHIVE }}
+
+  jar:
+    name: Build JAR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build assembly JAR
+        run: |
+          export CELLAR_VERSION="0.1.0-SNAPSHOT-$(git rev-parse --short HEAD)"
+          ./mill cli.assembly
+
+      - name: Rename JAR
+        run: cp out/cli/assembly.dest/out.jar cellar.jar
+
+      - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: jar
+          path: cellar.jar
+
+  release:
+    name: Publish rolling snapshot
+    needs: [build, jar]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+        with:
+          path: artifacts/
+          merge-multiple: true
+
+      - name: Generate SHA256 checksums
+        working-directory: artifacts
+        run: sha256sum *.tar.gz *.jar > checksums.txt
+
+      - name: Publish rolling snapshot release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
+        with:
+          tag_name: snapshot
+          target_commitish: ${{ github.sha }}
+          name: Development Snapshot
+          body: |
+            Rolling development build from `${{ github.sha }}` (`${{ github.ref_name }}`).
+
+            Unstable, overwritten on every snapshot run. Not published to Maven Central.
+          prerelease: true
+          make_latest: false
+          files: artifacts/*

--- a/README.md
+++ b/README.md
@@ -61,6 +61,18 @@ sudo mv cellar /usr/local/bin/
 
 To verify checksums and signatures, see [RELEASING.md](RELEASING.md).
 
+### Development snapshots
+
+Unstable builds of the latest development code are published to a rolling [`snapshot`](https://github.com/VirtusLab/cellar/releases/tag/snapshot) prerelease. The download URLs are stable and always serve the newest build:
+
+```sh
+# Linux x86_64 (also: linux-aarch64, macos-arm64, macos-x86_64)
+curl -fsSL https://github.com/VirtusLab/cellar/releases/download/snapshot/cellar-linux-x86_64.tar.gz | tar xz
+sudo mv cellar /usr/local/bin/
+```
+
+Snapshots are not published to Maven Central and are not picked up by `cs install`. See [RELEASING.md](RELEASING.md#development-snapshots) for how they are produced.
+
 ## Quick start
 
 ```sh

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -27,6 +27,33 @@ The Maven publish waits for the native-binary and JAR builds to succeed before u
 
 No container images are built or published by this release flow.
 
+## Development snapshots
+
+For unstable, GitHub-only builds of in-progress work there is a separate [Snapshot workflow](.github/workflows/snapshot.yml), triggered manually:
+
+```sh
+gh workflow run snapshot.yml                    # snapshot the current default branch
+gh workflow run snapshot.yml --ref my-feature   # snapshot a specific branch
+```
+
+Unlike the release flow, it builds from the **dispatched ref** (not pinned to `main`), so feature branches can be snapshotted. It:
+
+- Builds the native binaries + assembly JAR, stamping the version as `0.1.0-SNAPSHOT-<short-sha>`.
+- Publishes them to a single rolling `snapshot` prerelease, **overwriting** the assets on every run.
+- Attaches a `checksums.txt`.
+
+What it deliberately does **not** do: publish to Maven Central, sign with cosign, rewrite `flake.nix`, commit to `main`, or push a version tag.
+
+Because the tag is rolling, there is always exactly one snapshot release — nothing accumulates, so no cleanup is needed. Asset names are version-less (`cellar-<os>-<arch>.tar.gz`, `cellar.jar`) so download URLs stay stable:
+
+```
+https://github.com/VirtusLab/cellar/releases/download/snapshot/cellar-linux-x86_64.tar.gz
+```
+
+The release is marked `prerelease` and `make_latest: false`, so it never displaces the real "Latest release". Snapshots are not resolved by `cs install cellar`, which reads Maven metadata.
+
+> **Note** — the `snapshot` tag itself is not re-pointed once it exists (`target_commitish` only applies at tag creation); the release body always prints the actual built commit SHA, and the assets are always the newest build.
+
 ## Supported platforms
 
 | Platform | Runner | Archive |
@@ -109,7 +136,7 @@ Install cosign ([instructions](https://docs.sigstore.dev/cosign/system_config/in
 ```sh
 cosign verify-blob \
   --bundle checksums.txt.bundle \
-  --certificate-identity-regexp "https://github.com/simple-scala-tooling/cellar/.github/workflows/release.yml@refs/tags/v" \
+  --certificate-identity-regexp "https://github.com/VirtusLab/cellar/.github/workflows/release.yml@refs/tags/v" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
   checksums.txt
 ```


### PR DESCRIPTION
## What

Adds a manually-dispatched **Snapshot** workflow (`.github/workflows/snapshot.yml`) that publishes unstable development builds to GitHub only — no Maven Central involvement.

## How it works

- **On demand:** `gh workflow run snapshot.yml [--ref <branch>]`. Builds from the **dispatched ref** (not pinned to `main`), so feature branches can be snapshotted.
- Builds the 4 native binaries + assembly JAR, stamping the version as `0.1.0-SNAPSHOT-<short-sha>`.
- Publishes to a single **rolling `snapshot` prerelease**, overwriting the assets each run → exactly one snapshot exists at all times, so **no cleanup cron is needed**.
- Version-less asset names give **stable download URLs**, e.g. `…/releases/download/snapshot/cellar-linux-x86_64.tar.gz`.
- `prerelease: true` + `make_latest: false` → never displaces the real "Latest release".

## Deliberately *not* done (vs `release.yml`)

No Maven Central publish, no cosign signing, no `flake.nix` rewrite, no commit to `main`, no version tag. Snapshots are not resolved by `cs install`.

## Docs

- README: new **Development snapshots** install subsection.
- RELEASING.md: new **Development snapshots** section; also fixes a stale `simple-scala-tooling/cellar` → `VirtusLab/cellar` slug in the cosign verify example.

## Notes

Independent of the `active-installs-metric` work — branched off `main`, contains only the 3 snapshot-related files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)