### PR TITLE
Make snapshot releases compatible with immutable releases

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,9 +1,14 @@
 name: Snapshot
 
 # On-demand development snapshot. Builds the native binaries + JAR from the
-# dispatched ref and publishes them to a single rolling `snapshot` prerelease
-# whose assets are overwritten each run. No Maven publish, no tag/flake mutation
-# of `main`. Asset names are version-less so download URLs stay stable.
+# dispatched ref and publishes them to a fresh, immutable `snapshot-<sha>-<run>`
+# prerelease each run, then prunes older snapshot releases so only the newest
+# survives. No Maven publish, no tag/flake mutation of `main`.
+#
+# Each run uses a unique tag: immutable releases forbid mutating an existing
+# release (target_commitish/assets) and forbid ever reusing a tag name that
+# belonged to an immutable release — so a single rolling `snapshot` tag is not
+# possible. Consumers resolve the newest build via the GitHub API (see README).
 on:
   workflow_dispatch:
 
@@ -107,16 +112,36 @@ jobs:
         working-directory: artifacts
         run: sha256sum *.tar.gz *.jar > checksums.txt
 
-      - name: Publish rolling snapshot release
+      - name: Compute snapshot tag
+        id: tag
+        # run_number keeps the tag unique even when the same commit is snapshotted
+        # twice — an immutable release burns its tag name permanently.
+        run: echo "tag=snapshot-$(git rev-parse --short HEAD)-${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish snapshot release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
-          tag_name: snapshot
+          tag_name: ${{ steps.tag.outputs.tag }}
           target_commitish: ${{ github.sha }}
-          name: Development Snapshot
+          name: Development Snapshot (${{ steps.tag.outputs.tag }})
           body: |
-            Rolling development build from `${{ github.sha }}` (`${{ github.ref_name }}`).
+            Unstable development build from `${{ github.sha }}` (`${{ github.ref_name }}`).
 
-            Unstable, overwritten on every snapshot run. Not published to Maven Central.
+            Superseded by the next snapshot run and not published to Maven Central.
           prerelease: true
           make_latest: false
           files: artifacts/*
+
+      - name: Prune older snapshots
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # Deleting an immutable release (and its tag) is allowed; only tag *reuse*
+        # is blocked, which unique per-run tags avoid. Keeps just the newest snapshot.
+        run: |
+          KEEP="${{ steps.tag.outputs.tag }}"
+          gh release list --repo "$GITHUB_REPOSITORY" --limit 100 --json tagName \
+            --jq '.[] | select(.tagName == "snapshot" or (.tagName | startswith("snapshot-"))) | .tagName' \
+          | while read -r tag; do
+              [ "$tag" = "$KEEP" ] && continue
+              gh release delete "$tag" --repo "$GITHUB_REPOSITORY" --cleanup-tag --yes || true
+            done

--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ To verify checksums and signatures, see [RELEASING.md](RELEASING.md).
 
 ### Development snapshots
 
-Unstable builds of the latest development code are published to a rolling [`snapshot`](https://github.com/VirtusLab/cellar/releases/tag/snapshot) prerelease. The download URLs are stable and always serve the newest build:
+Unstable builds of the latest development code are published as `snapshot-<sha>-<run>` [prereleases](https://github.com/VirtusLab/cellar/releases). Each run publishes a fresh, immutable prerelease and prunes the previous one, so there is always exactly one snapshot. Because immutable releases require a unique tag per build, download URLs are no longer static — resolve the newest snapshot with `gh`:
 
 ```sh
+# Latest snapshot tag (requires the GitHub CLI, `gh`)
+TAG=$(gh release list --repo VirtusLab/cellar --limit 100 --json tagName \
+  --jq 'map(.tagName | select(startswith("snapshot-"))) | first')
+
 # Linux x86_64 (also: linux-aarch64, macos-arm64, macos-x86_64)
-curl -fsSL https://github.com/VirtusLab/cellar/releases/download/snapshot/cellar-linux-x86_64.tar.gz | tar xz
+gh release download "$TAG" --repo VirtusLab/cellar --pattern 'cellar-linux-x86_64.tar.gz' --output - | tar xz
 sudo mv cellar /usr/local/bin/
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -39,20 +39,17 @@ gh workflow run snapshot.yml --ref my-feature   # snapshot a specific branch
 Unlike the release flow, it builds from the **dispatched ref** (not pinned to `main`), so feature branches can be snapshotted. It:
 
 - Builds the native binaries + assembly JAR, stamping the version as `0.1.0-SNAPSHOT-<short-sha>`.
-- Publishes them to a single rolling `snapshot` prerelease, **overwriting** the assets on every run.
+- Publishes them to a fresh `snapshot-<short-sha>-<run-number>` prerelease.
 - Attaches a `checksums.txt`.
+- Prunes any older `snapshot`/`snapshot-*` releases (and their tags), so exactly one snapshot survives.
 
 What it deliberately does **not** do: publish to Maven Central, sign with cosign, rewrite `flake.nix`, commit to `main`, or push a version tag.
 
-Because the tag is rolling, there is always exactly one snapshot release — nothing accumulates, so no cleanup is needed. Asset names are version-less (`cellar-<os>-<arch>.tar.gz`, `cellar.jar`) so download URLs stay stable:
-
-```
-https://github.com/VirtusLab/cellar/releases/download/snapshot/cellar-linux-x86_64.tar.gz
-```
+Each run uses a **unique tag** because [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) are enabled on the repo: an immutable release cannot be mutated (so `target_commitish` and assets can't be overwritten on a reused tag), and a tag name that once belonged to an immutable release **can never be reused**. A single rolling `snapshot` tag is therefore impossible; `<run-number>` keeps the tag unique even across re-snapshots of the same commit. Deleting an immutable release and its tag *is* allowed, which is how pruning works.
 
 The release is marked `prerelease` and `make_latest: false`, so it never displaces the real "Latest release". Snapshots are not resolved by `cs install cellar`, which reads Maven metadata.
 
-> **Note** — the `snapshot` tag itself is not re-pointed once it exists (`target_commitish` only applies at tag creation); the release body always prints the actual built commit SHA, and the assets are always the newest build.
+Because tags are no longer static, download URLs change every run. Consumers resolve the newest snapshot via the GitHub API — see [README.md](README.md#development-snapshots).
 
 ## Supported platforms
 


### PR DESCRIPTION
## Problem

The snapshot workflow failed with:

> `target_commitish cannot be changed when release is immutable`

The rolling `snapshot` tag reused and overwrote a single release on every run. With **immutable releases** enabled (GA'd 2025-10-28, no prerelease exemption) that model is impossible:

- A published release **cannot be mutated** → the `target_commitish` error above.
- A tag name that once belonged to an immutable release **can never be reused** — so delete-and-recreate on the same `snapshot` tag would also fail, permanently.

The stable download URL was exactly the property immutability forbids.

## Change

Immutable releases are preserved. The snapshot flow now:

- Uses a **unique tag per run**: `snapshot-<short-sha>-<run-number>` (`run-number` guards against re-snapshotting the same commit, which would otherwise burn a tag name forever).
- Publishes a fresh immutable prerelease under that tag.
- **Prunes** older `snapshot`/`snapshot-*` releases + tags (`gh release delete --cleanup-tag`; deletion is allowed under immutability, only tag *reuse* is blocked), so exactly one snapshot survives — same "nothing accumulates" behavior as before.

## Tradeoff

Download URLs are now **dynamic** — `README.md` resolves the newest snapshot via `gh release list`/`gh release download`. A static URL is not possible while immutable releases are on; the only alternative would be moving rolling artifacts off Releases (branch/Pages).

## Files

- `.github/workflows/snapshot.yml` — unique tag + prune step
- `README.md` — `gh`-based snapshot download instructions
- `RELEASING.md` — documents the new model and the immutability constraints

## Verification

- Workflow YAML parses cleanly.
- The `--jq` prune filter (matches legacy `snapshot` and `snapshot-*`) and the latest-tag selector verified against sample data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)