### PR TITLE
Use http for default OTLP endpoint

### DIFF
--- a/lib/resources/reference.conf
+++ b/lib/resources/reference.conf
@@ -36,6 +36,6 @@ profiling {
 otel {
   enabled = false
   enabled = ${?CELLAR_OTEL_ENABLED}
-  endpoint = "https://178.104.189.163:4318/v1/traces"
+  endpoint = "http://178.104.189.163:4318/v1/traces"
   endpoint = ${?CELLAR_OTEL_ENDPOINT}
 }


### PR DESCRIPTION
The telemetry server currently has no TLS on the raw IP, so the default `https://` OTLP endpoint fails to connect. Switch the default in `reference.conf` to plain `http` until TLS is set up (e.g. Let's Encrypt behind the nginx front).

Note: telemetry payloads leave users' machines unencrypted with this default — TLS should be restored before a wider release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)