### PR TITLE
Pin release notes baseline to latest stable release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,9 +191,24 @@ jobs:
           git tag "v${VERSION}"
           git push origin "v${VERSION}"
 
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        # generate_release_notes lets GitHub pick the previous release itself,
+        # and it picks the newest snapshot prerelease when one exists, dropping
+        # every change between the last stable release and that snapshot (bit
+        # v0.1.0-M10). Pin previous_tag_name to the latest stable release.
+        run: |
+          PREV_TAG=$(gh api "repos/${{ github.repository }}/releases" \
+            -q '[.[] | select(.prerelease or .draft | not)][0].tag_name')
+          gh api "repos/${{ github.repository }}/releases/generate-notes" \
+            -f tag_name="v${{ inputs.version }}" \
+            ${PREV_TAG:+-f previous_tag_name="$PREV_TAG"} \
+            -q .body > release-notes.md
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
         with:
           tag_name: v${{ inputs.version }}
           files: artifacts/*
-          generate_release_notes: true
+          body_path: release-notes.md


### PR DESCRIPTION
GitHub's auto-generated release notes pick the newest release as the baseline — including snapshot prereleases. v0.1.0-M10's changelog was generated against `snapshot-5e9cef3-3` and silently dropped every PR merged between v0.1.0-M9 and that snapshot.

This replaces `generate_release_notes: true` with an explicit `gh api releases/generate-notes` call that pins `previous_tag_name` to the latest stable (non-prerelease, non-draft) release, so snapshot releases can never shift the changelog baseline again.

The v0.1.0-M10 release notes have already been regenerated against v0.1.0-M9 and updated in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)