### PR TITLE
Fix plugin install by using in-repo marketplace source

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,15 +10,14 @@
     {
       "name": "cellar",
       "description": "Look up the public API of any JVM dependency (Scala 3, Scala 2, Java) from the terminal",
-      "source": {
-        "source": "github",
-        "repo": "VirtusLab/cellar"
-      },
+      "source": "./",
+      "version": "0.1.0",
+      "repository": "https://github.com/VirtusLab/cellar",
       "category": "development",
       "license": "MPL-2.0",
       "keywords": ["scala", "java", "jvm", "api", "documentation"],
       "author": {
-        "name": "rochala"
+        "name": "VirtusLab"
       },
       "homepage": "https://github.com/VirtusLab/cellar"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,6 +2,9 @@
   "name": "cellar",
   "version": "0.1.0",
   "description": "Look up the public API of any JVM dependency (Scala 3, Scala 2, Java) from the terminal",
-  "repository": "https://github.com/virtuslab/cellar",
-  "license": "MPL-2.0"
+  "repository": "https://github.com/VirtusLab/cellar",
+  "license": "MPL-2.0",
+  "author": {
+    "name": "VirtusLab"
+  }
 }


### PR DESCRIPTION
The `github` source object made Claude Code clone VirtusLab/cellar a second time over SSH (git@github.com), which fails for anyone without a GitHub SSH key. The plugin lives at the root of this repo, which is already cloned when the marketplace is added, so point at it with a relative source instead.

Also set the plugin author and fix the repository URL casing.